### PR TITLE
Add some tests to be used by the CI

### DIFF
--- a/server/common_test.go
+++ b/server/common_test.go
@@ -1,0 +1,59 @@
+package server_test
+
+import (
+	"database/sql"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/stretchr/testify/suite"
+)
+
+func GetResponse(method string, path string, body io.Reader) (*http.Response, error) {
+	req, err := http.NewRequest(method, path, body)
+	if err != nil {
+		return nil, fmt.Errorf("it should be possible to build a request; %s", err.Error())
+	}
+
+	cli := &http.Client{}
+	resp, err := cli.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("the server should answer with a response; %s", err.Error())
+	}
+
+	return resp, nil
+}
+
+type ClientTestSuite struct {
+	suite.Suite
+}
+
+func (c *ClientTestSuite) AssertResponseBody(resp *http.Response, expectedContent string, msg string) {
+	c.Require().NotNil(resp, "the response body should not be nil")
+	respBody, err := ioutil.ReadAll(resp.Body)
+	c.Require().Nil(err, "the response body should be readable")
+
+	defer resp.Body.Close()
+	c.Equal(expectedContent, string(respBody), msg)
+}
+
+func (c *ClientTestSuite) AssertResponseStatus(resp *http.Response, expectedStatus int, msg string) {
+	c.Require().NotNil(resp, "the response body should not be nil")
+	c.Equal(expectedStatus, resp.StatusCode, fmt.Sprintf("status should be %d; %s", expectedStatus, msg))
+}
+
+func (c *ClientTestSuite) AssertResponseBodyStatus(resp *http.Response, expectedStatus int, expectedContent string, msg string) {
+	c.AssertResponseBody(resp, expectedContent, msg)
+	c.AssertResponseStatus(resp, expectedStatus, "")
+}
+
+type mockDB struct{}
+
+func (db *mockDB) Close() error {
+	return nil
+}
+
+func (db *mockDB) Query(query string, args ...interface{}) (*sql.Rows, error) {
+	return nil, nil
+}

--- a/server/handler/query.go
+++ b/server/handler/query.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/src-d/gitbase-playground/server/serializer"
+	"github.com/src-d/gitbase-playground/server/service"
 	"gopkg.in/bblfsh/sdk.v1/uast"
 
 	"github.com/go-sql-driver/mysql"
@@ -46,7 +47,7 @@ func genericVals(colTypes []string) []interface{} {
 
 // Query returns a function that forwards an SQL query to gitbase and returns
 // the rows as JSON
-func Query(db *sql.DB) RequestProcessFunc {
+func Query(db service.SQLDB) RequestProcessFunc {
 	return func(r *http.Request) (*serializer.Response, error) {
 		var queryRequest queryRequest
 		body, err := ioutil.ReadAll(r.Body)

--- a/server/handler/query_test.go
+++ b/server/handler/query_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/src-d/gitbase-playground/server/handler"
 	"github.com/src-d/gitbase-playground/server/serializer"
+	"github.com/src-d/gitbase-playground/server/service"
 
 	"github.com/kelseyhightower/envconfig"
 	"github.com/pressly/lg"
@@ -28,11 +29,11 @@ type appConfig struct {
 
 type QuerySuite struct {
 	suite.Suite
-	db      *sql.DB
+	db      service.SQLDB
 	handler http.Handler
 }
 
-func setupDB(require *require.Assertions) *sql.DB {
+func setupDB(require *require.Assertions) service.SQLDB {
 	var conf appConfig
 	envconfig.MustProcess("GITBASEPG", &conf)
 

--- a/server/handler/tables.go
+++ b/server/handler/tables.go
@@ -1,15 +1,15 @@
 package handler
 
 import (
-	"database/sql"
 	"net/http"
 	"strings"
 
 	"github.com/src-d/gitbase-playground/server/serializer"
+	"github.com/src-d/gitbase-playground/server/service"
 )
 
 // Tables returns a function that calls /query with the SQL "SHOW TABLES"
-func Tables(db *sql.DB) RequestProcessFunc {
+func Tables(db service.SQLDB) RequestProcessFunc {
 	return func(r *http.Request) (*serializer.Response, error) {
 		req, _ := http.NewRequest("POST", "/query",
 			strings.NewReader(`{ "query": "SHOW TABLES" }`))

--- a/server/handler/tables_test.go
+++ b/server/handler/tables_test.go
@@ -1,13 +1,13 @@
 package handler_test
 
 import (
-	"database/sql"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/sirupsen/logrus"
 	"github.com/src-d/gitbase-playground/server/handler"
+	"github.com/src-d/gitbase-playground/server/service"
 
 	"github.com/pressly/lg"
 	"github.com/stretchr/testify/suite"
@@ -18,7 +18,7 @@ import (
 
 type TablesSuite struct {
 	suite.Suite
-	db      *sql.DB
+	db      service.SQLDB
 	handler http.Handler
 }
 

--- a/server/router.go
+++ b/server/router.go
@@ -1,10 +1,10 @@
 package server
 
 import (
-	"database/sql"
 	"net/http"
 
 	"github.com/src-d/gitbase-playground/server/handler"
+	"github.com/src-d/gitbase-playground/server/service"
 
 	"github.com/go-chi/chi"
 	"github.com/go-chi/chi/middleware"
@@ -18,7 +18,7 @@ func Router(
 	logger *logrus.Logger,
 	static *handler.Static,
 	version string,
-	db *sql.DB,
+	db service.SQLDB,
 ) http.Handler {
 
 	// cors options

--- a/server/router_test.go
+++ b/server/router_test.go
@@ -1,0 +1,68 @@
+package server_test
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/src-d/gitbase-playground/server"
+	"github.com/src-d/gitbase-playground/server/handler"
+	"github.com/src-d/gitbase-playground/server/service"
+
+	"github.com/stretchr/testify/suite"
+)
+
+func TestRouterTestSuite(t *testing.T) {
+	suite.Run(t, new(RouterTestSuite))
+}
+
+type RouterTestSuite struct {
+	ClientTestSuite
+	router http.Handler
+	server *httptest.Server
+	db     service.SQLDB
+}
+
+const version = "test-version"
+
+func (s *RouterTestSuite) SetupSuite() {
+	logger := service.NewLogger("dev")
+	staticHandler := &handler.Static{}
+	s.db = &mockDB{}
+	s.router = server.Router(
+		logger,
+		staticHandler,
+		version,
+		s.db,
+	)
+}
+
+func (s *RouterTestSuite) SetupTest() {
+	s.server = httptest.NewServer(s.router)
+}
+
+func (s *RouterTestSuite) TearDownTest() {
+	s.server.Close()
+}
+
+func (s *RouterTestSuite) TearDownSuite() {
+	s.db.Close()
+}
+
+func (s *RouterTestSuite) GetResponse(method string, path string, body io.Reader) *http.Response {
+	url := s.server.URL + path
+	response, err := GetResponse(method, url, body)
+	if err != nil {
+		s.Fail(err.Error())
+	}
+
+	return response
+}
+
+func (s *RouterTestSuite) TestVersion() {
+	expectedVersion := fmt.Sprintf(`{"status":200,"data":{"version":"%s"}}`, version)
+	response := s.GetResponse("GET", "/version", nil)
+	s.AssertResponseBodyStatus(response, 200, expectedVersion, "version should be served")
+}

--- a/server/serializer/serializers_test.go
+++ b/server/serializer/serializers_test.go
@@ -1,0 +1,1 @@
+package serializer_test

--- a/server/service/common.go
+++ b/server/service/common.go
@@ -1,0 +1,9 @@
+package service
+
+import "database/sql"
+
+// SQLDB describes a *sql.DB
+type SQLDB interface {
+	Close() error
+	Query(query string, args ...interface{}) (*sql.Rows, error)
+}

--- a/server/service/common_test.go
+++ b/server/service/common_test.go
@@ -1,0 +1,1 @@
+package service_test


### PR DESCRIPTION
required by #1

Added tests:
- 345e890 It was added some integration tests to ensure that `/version` endpoint works,
- fe788ec It was added empty tests to get a proper coverage report,

Others:
- 86e1d6b To make the app easily testable it was used an interface of `*sql.DB`
 