### PR TITLE
 Pass env vars from backend to frontend

### DIFF
--- a/cmd/gitbase-playground/main.go
+++ b/cmd/gitbase-playground/main.go
@@ -23,20 +23,18 @@ var version = "dev"
 // The next release should make this parameter optional for us:
 // https://github.com/go-sql-driver/mysql/pull/680
 type appConfig struct {
-	Env       string `envconfig:"ENV" default:"production"`
-	Host      string `envconfig:"HOST" default:"0.0.0.0"`
-	Port      int    `envconfig:"PORT" default:"8080"`
-	ServerURL string `envconfig:"SERVER_URL"`
-	DBConn    string `envconfig:"DB_CONNECTION" default:"gitbase@tcp(localhost:3306)/none?maxAllowedPacket=4194304"`
+	Env         string `envconfig:"ENV" default:"production"`
+	Host        string `envconfig:"HOST" default:"0.0.0.0"`
+	Port        int    `envconfig:"PORT" default:"8080"`
+	ServerURL   string `envconfig:"SERVER_URL"`
+	DBConn      string `envconfig:"DB_CONNECTION" default:"gitbase@tcp(localhost:3306)/none?maxAllowedPacket=4194304"`
+	SelectLimit int    `envconfig:"SELECT_LIMIT" default:"100"`
 }
 
 func main() {
 	// main configuration
 	var conf appConfig
 	envconfig.MustProcess("GITBASEPG", &conf)
-	if conf.ServerURL == "" {
-		conf.ServerURL = fmt.Sprintf("//localhost:%d", conf.Port)
-	}
 
 	// logger
 	logger := service.NewLogger(conf.Env)
@@ -48,7 +46,7 @@ func main() {
 	}
 	defer db.Close()
 
-	static := handler.NewStatic("build/public", conf.ServerURL)
+	static := handler.NewStatic("frontend/build", conf.ServerURL, conf.SelectLimit)
 
 	// start the router
 	router := server.Router(logger, static, version, db)

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -26,6 +26,7 @@
       You need to enable JavaScript to run this app.
     </noscript>
     <div id="root"></div>
+    <script>window.gitbasepg = window.REPLACE_BY_SERVER || undefined;</script>
     <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,3 +1,10 @@
+const envVars = window.gitbasepg || { SERVER_URL: '', SELECT_LIMIT: 100 };
+
+const serverUrl = envVars.SERVER_URL;
+const selectLimit = envVars.SELECT_LIMIT;
+
+const apiUrl = url => `${serverUrl}${url}`;
+
 function checkStatus(resp) {
   if (resp.status < 200 || resp.status >= 300) {
     return resp
@@ -58,7 +65,7 @@ function apiCall(url, options = {}) {
     }
   }
 
-  return fetch(url, fetchOptions)
+  return fetch(apiUrl(url), fetchOptions)
     .then(checkStatus)
     .then(resp => resp.json())
     .then(json => {
@@ -73,7 +80,10 @@ function apiCall(url, options = {}) {
 function query(sql) {
   return apiCall(`/query`, {
     method: 'POST',
-    body: { query: sql }
+    body: {
+      query: sql,
+      limit: selectLimit
+    }
   });
 }
 

--- a/server/handler/static_files.go
+++ b/server/handler/static_files.go
@@ -15,18 +15,20 @@ type Static struct {
 }
 
 // NewStatic creates new Static
-func NewStatic(dir, serverURL string) *Static {
+func NewStatic(dir, serverURL string, selectLimit int) *Static {
 	return &Static{
 		dir: dir,
 		options: options{
-			ServerURL: serverURL,
+			ServerURL:   serverURL,
+			SelectLimit: selectLimit,
 		},
 	}
 }
 
 // struct which will be marshalled and exposed to frontend
 type options struct {
-	ServerURL string `json:"SERVER_URL"`
+	ServerURL   string `json:"SERVER_URL"`
+	SelectLimit int    `json:"SELECT_LIMIT"`
 }
 
 // ServeHTTP serves any static file from static directory or fallbacks on index.hml


### PR DESCRIPTION
Part of #4, depends on #16.
The only new commit is cec12d4.

It uses the same mechanism as code-annotation.