### PR TITLE
Add docker-compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,7 @@ front-lint:
 
 front-build: build-path
 	$(YARN) build
+	$(REMOVE) $(BUILD_PATH)/public
 	$(MOVE) $(FRONTEND_BUILD_PATH) $(BUILD_PATH)/public
 
 front-fix-lint-errors:

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ YARN := yarn --cwd $(FRONTEND_PATH)
 REMOVE := rm -rf
 MOVE := mv
 MKDIR := mkdir -p
+COMPOSE_UP := docker-compose
 
 # Default rule
 all:
@@ -68,6 +69,16 @@ build-path:
 
 serve: | front-build back-start
 
+compose-serve: | require-repos-folder front-dependencies build
+	GITBASEPG_REPOS_FOLDER=${GITBASEPG_REPOS_FOLDER} \
+		$(COMPOSE_UP) -f docker-compose.yml -f docker-compose.build.yml up --force-recreate --build
+
+require-repos-folder:
+	@if [[ -z "$(GITBASEPG_REPOS_FOLDER)" ]]; then \
+		echo "error. undefined 'GITBASEPG_REPOS_FOLDER' to be served under gitbase"; \
+		exit 1; \
+	fi
+	$(MKDIR) $(GITBASEPG_REPOS_FOLDER)
 
 # Backend
 

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -1,0 +1,6 @@
+version: '3.3'
+
+services:
+  playground:
+    image: gitbase-playground-dev
+    build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     environment:
       BBLFSH_ENDPOINT: bblfsh:9432
     volumes:
-      - ${REPOS_FOLDER}:/opt/repos
+      - ${GITBASEPG_REPOS_FOLDER}:/opt/repos
   bblfsh:
     image: "bblfsh/bblfshd"
     privileged: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3.3'
+
+services:
+  playground:
+    image: "srcd/gitbase-playground"
+    ports:
+      - "8080:8080"
+    environment:
+      GITBASEPG_ENV: ${GITBASEPG_ENV}
+      GITBASEPG_DB_CONNECTION: gitbase@tcp(gitbase:3306)/none?maxAllowedPacket=4194304
+  gitbase:
+    image: "srcd/gitbase"
+    environment:
+      BBLFSH_ENDPOINT: bblfsh:9432
+    volumes:
+      - ${REPOS_FOLDER}:/opt/repos
+  bblfsh:
+    image: "bblfsh/bblfshd"
+    privileged: true
+    volumes:
+      - type: volume
+        source: drivers
+        target: /var/lib/bblfshd
+    entrypoint: ["/bin/sh"]
+    command:
+    - "-c"
+    - "bblfshd & sleep 5 && bblfshctl driver install --recommended && tail -f /dev/null"
+
+volumes:
+  drivers:

--- a/docs/quickstart-manually.md
+++ b/docs/quickstart-manually.md
@@ -1,0 +1,67 @@
+# Quickstart
+
+You can locally build and deploy `gitbase-playground` and its dependencies using [`docker-compose`](https://docs.docker.com/compose/install/)
+
+If you preffer to run `gitbase-playground` with [`docker-compose`](https://docs.docker.com/compose) (without taking care of the app dependencies), you can follow [the playground compose quickstart](quickstart.md)
+
+
+## Run bblfsh and gitbase Dependencies
+
+It is recommended to read about `bblfsh` and `gitbase` from its own documentation, but here is a small guide about how to run both easily:
+
+Launch [bblfshd](https://github.com/bblfsh/bblfshd) and install the drivers. More info in the [bblfshd documentation](https://doc.bblf.sh/user/getting-started.html):
+
+```bash
+$ docker run --privileged
+    --publish 9432:9432
+    --volume /var/lib/bblfshd:/var/lib/bblfshd
+    --name bblfsh
+    bblfsh/bblfshd
+$ docker exec -it bblfsh
+    bblfshctl driver install --recommended
+```
+
+[gitbase](https://github.com/src-d/gitbase) will serve git repositories, so it is needed to populate a directory with them:
+
+```bash
+$ mkdir -p ~/gitbase/repos
+$ git clone git@github.com:src-d/go-git-fixtures.git ~/gitbase/repos/go-git-fixtures
+```
+
+Install and run [gitbase](https://github.com/src-d/gitbase):
+
+```bash
+# This quickstart is using a custom gitbase image until the official `srcd/gitbase` image is provided
+# See: https://github.com/src-d/gitbase/issues/262
+$ docker run
+    --publish 3306:3306
+    --link bblfsh
+    --volume ~/gitbase/repos:/opt/repos
+    --env BBLFSH_ENDPOINT=bblfsh:9432
+    --name gitbase
+    srcd/gitbase:latest
+```
+
+
+## Run gitbase-playground
+
+Once bblfsh and gitbase are running and accessible, you can serve the playground:
+
+```bash
+$ docker run -d
+    --publish 8080:8080
+    --link gitbase
+    --env GITBASEPG_ENV=dev
+    --env GITBASEPG_DB_CONNECTION="gitbase@tcp(gitbase:3306)/none?maxAllowedPacket=4194304"
+    --name gitbase_playground
+   srcd/gitbase-playground:latest
+```
+
+Once the server is running &ndash;with its default values&ndash;, it will be accessible through: http://localhost:8080
+
+You have more information about the [playground architecture](CONTRIBUTING.md#architecture), [development guides](CONTRIBUTING.md#development) and [configuration options](CONTRIBUTING.md#configuration) in the [CONTRIBUTING.md](CONTRIBUTING.md).
+
+
+## Run a Query
+
+You will find more info about how to run queries using the playground API on the [rest-api guide](rest-api.md)

--- a/docs/quickstart-manually.md
+++ b/docs/quickstart-manually.md
@@ -12,12 +12,12 @@ It is recommended to read about `bblfsh` and `gitbase` from its own documentatio
 Launch [bblfshd](https://github.com/bblfsh/bblfshd) and install the drivers. More info in the [bblfshd documentation](https://doc.bblf.sh/user/getting-started.html):
 
 ```bash
-$ docker run --privileged
-    --publish 9432:9432
-    --volume /var/lib/bblfshd:/var/lib/bblfshd
-    --name bblfsh
+$ docker run --privileged \
+    --publish 9432:9432 \
+    --volume /var/lib/bblfshd:/var/lib/bblfshd \
+    --name bblfsh \
     bblfsh/bblfshd
-$ docker exec -it bblfsh
+$ docker exec -it bblfsh \
     bblfshctl driver install --recommended
 ```
 
@@ -31,14 +31,12 @@ $ git clone git@github.com:src-d/go-git-fixtures.git ~/gitbase/repos/go-git-fixt
 Install and run [gitbase](https://github.com/src-d/gitbase):
 
 ```bash
-# This quickstart is using a custom gitbase image until the official `srcd/gitbase` image is provided
-# See: https://github.com/src-d/gitbase/issues/262
-$ docker run
-    --publish 3306:3306
-    --link bblfsh
-    --volume ~/gitbase/repos:/opt/repos
-    --env BBLFSH_ENDPOINT=bblfsh:9432
-    --name gitbase
+$ docker run \
+    --publish 3306:3306 \
+    --link bblfsh \
+    --volume ~/gitbase/repos:/opt/repos \
+    --env BBLFSH_ENDPOINT=bblfsh:9432 \
+    --name gitbase \
     srcd/gitbase:latest
 ```
 
@@ -48,12 +46,12 @@ $ docker run
 Once bblfsh and gitbase are running and accessible, you can serve the playground:
 
 ```bash
-$ docker run -d
-    --publish 8080:8080
-    --link gitbase
-    --env GITBASEPG_ENV=dev
-    --env GITBASEPG_DB_CONNECTION="gitbase@tcp(gitbase:3306)/none?maxAllowedPacket=4194304"
-    --name gitbase_playground
+$ docker run -d \
+    --publish 8080:8080 \
+    --link gitbase \
+    --env GITBASEPG_ENV=dev \
+    --env GITBASEPG_DB_CONNECTION="gitbase@tcp(gitbase:3306)/none?maxAllowedPacket=4194304" \
+    --name gitbase_playground \
    srcd/gitbase-playground:latest
 ```
 

--- a/docs/quickstart-manually.md
+++ b/docs/quickstart-manually.md
@@ -2,7 +2,7 @@
 
 You can locally build and deploy `gitbase-playground` and its dependencies using [`docker-compose`](https://docs.docker.com/compose/install/)
 
-If you preffer to run `gitbase-playground` with [`docker-compose`](https://docs.docker.com/compose) (without taking care of the app dependencies), you can follow [the playground compose quickstart](quickstart.md)
+If you prefer to run `gitbase-playground` with [`docker-compose`](https://docs.docker.com/compose) (without taking care of the app dependencies), you can follow [the playground compose quickstart](quickstart.md)
 
 
 ## Run bblfsh and gitbase Dependencies

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,31 +1,65 @@
 # Quickstart
 
-You can locally build and deploy `gitbase-playground` and its dependencies using [`docker-compose`](https://docs.docker.com/compose/install/)
+You can locally build and deploy `gitbase-playground` and its dependencies using [`docker-compose`](https://docs.docker.com/compose/install/).
+Docker compose will run three different containers: for the playground frontend itself, gitbase and bblfsh services. It will be the [latest gitbase version](https://hub.docker.com/r/srcd/gitbase/tags/) and [latest bblfsh version](https://hub.docker.com/r/bblfsh/bblfshd/tags/).
 
 If you preffer to run `gitbase-playground` dependencies manually, you can follow [the alternative playground quickstart](quickstart-manually.md)
 
+
+## Download the project
+
+```bash
+$ git clone git@github.com:src-d/gitbase-playground.git gitbase-playground
+$ cd gitbase-playground
+```
+
+This guide will assume you're running all commands from `gitbase-playground` sources directory
+
+
 ## Populate the database
 
-Populate a directory with some git repositories to be served by [gitbase](https://github.com/src-d/gitbase):
+It is needed to populate a directory with some git repositories to be served by [gitbase](https://github.com/src-d/gitbase) before running it.
+
+example:
 
 ```bash
 $ git clone git@github.com:src-d/gitbase-playground.git ./repos/gitbase-playground
 $ git clone git@github.com:src-d/go-git-fixtures.git ./repos/go-git-fixtures
 ```
 
+Everytime you want to add a new repository to gitbase, the application should be restarted.
+
+
 ## Run the application
 
-Once bblfsh and gitbase are running and accessible, you can serve the playground:
+Run the [latest released version of the frontend](https://hub.docker.com/r/srcd/gitbase-playground/tags/):
 
 ```bash
-$ GITBASEPG_ENV=dev REPOS_FOLDER=./repos GITBASEPG_ENV=dev docker-compose up
+$ GITBASEPG_REPOS_FOLDER=./repos docker-compose up --force-recreate
 ```
+
+If you want to build and run the playground from sources instead of using the last released version you can do so:
+
+<details>
+<pre>
+$ GITBASEPG_REPOS_FOLDER=./repos make compose-serve
+</pre>
+</details>
+
+## Stop the Application
+
+To kill the running containers just `Ctrl+C`
+
+To delete the containers run `docker-compose rm -f`
+
+
+## Access to the Playground and Run a Query
 
 Once the server is running &ndash;with its default values&ndash;, it will be accessible through: http://localhost:8080
 
-You have more information about the [playground architecture](CONTRIBUTING.md#architecture), [development guides](CONTRIBUTING.md#development) and [configuration options](CONTRIBUTING.md#configuration) in the [CONTRIBUTING.md](CONTRIBUTING.md).
-
-
-## Run a Query
-
 You will find more info about how to run queries using the playground API on the [rest-api guide](rest-api.md)
+
+
+## More Info
+
+You have more information about the [playground architecture](CONTRIBUTING.md#architecture), [development guides](CONTRIBUTING.md#development) and [configuration options](CONTRIBUTING.md#configuration) in the [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,55 +1,24 @@
 # Quickstart
 
-## Run bblfsh and gitbase Dependencies
+You can locally build and deploy `gitbase-playground` and its dependencies using [`docker-compose`](https://docs.docker.com/compose/install/)
 
-It is recommended to read about `bblfsh` and `gitbase` from its own documentation, but here is a small guide about how to run both easily:
+If you preffer to run `gitbase-playground` dependencies manually, you can follow [the alternative playground quickstart](quickstart-manually.md)
 
-Launch [bblfshd](https://github.com/bblfsh/bblfshd) and install the drivers. More info in the [bblfshd documentation](https://doc.bblf.sh/user/getting-started.html):
+## Populate the database
 
-```bash
-$ docker run --privileged
-    --publish 9432:9432
-    --volume /var/lib/bblfshd:/var/lib/bblfshd
-    --name bblfsh
-    bblfsh/bblfshd
-$ docker exec -it bblfsh
-    bblfshctl driver install --recommended
-```
-
-[gitbase](https://github.com/src-d/gitbase) will serve git repositories, so it is needed to populate a directory with them:
+Populate a directory with some git repositories to be served by [gitbase](https://github.com/src-d/gitbase):
 
 ```bash
-$ mkdir -p ~/gitbase/repos
-$ git clone git@github.com:src-d/go-git-fixtures.git ~/gitbase/repos/go-git-fixtures
+$ git clone git@github.com:src-d/gitbase-playground.git ./repos/gitbase-playground
+$ git clone git@github.com:src-d/go-git-fixtures.git ./repos/go-git-fixtures
 ```
 
-Install and run [gitbase](https://github.com/src-d/gitbase):
-
-```bash
-# This quickstart is using a custom gitbase image until the official `srcd/gitbase` image is provided
-# See: https://github.com/src-d/gitbase/issues/262
-$ docker run
-    --publish 3306:3306
-    --link bblfsh
-    --volume ~/gitbase/repos:/opt/repos
-    --env BBLFSH_ENDPOINT=bblfsh:9432
-    --name gitbase
-    srcd/gitbase:latest
-```
-
-
-## Run gitbase-playground
+## Run the application
 
 Once bblfsh and gitbase are running and accessible, you can serve the playground:
 
 ```bash
-$ docker run -d
-    --publish 8080:8080
-    --link gitbase
-    --env GITBASEPG_ENV=dev
-    --env GITBASEPG_DB_CONNECTION="gitbase@tcp(gitbase:3306)/none?maxAllowedPacket=4194304"
-    --name gitbase_playground
-   srcd/gitbase-playground:latest
+$ GITBASEPG_ENV=dev REPOS_FOLDER=./repos GITBASEPG_ENV=dev docker-compose up
 ```
 
 Once the server is running &ndash;with its default values&ndash;, it will be accessible through: http://localhost:8080


### PR DESCRIPTION
If accepted it would be only needed to run:

Run latest released image:
```shell
$ GITBASEPG_REPOS_FOLDER=./repos docker-compose up
```

Run from sources (useful when developing or willing to run `tip` of `master`...)
```shell
$ GITBASEPG_REPOS_FOLDER=./repos make compose-serve
```