### PR TITLE
Add CodeMirror editor with sql syntax and autocomplete

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,9 +4,11 @@
   "private": true,
   "dependencies": {
     "bootstrap": "3",
+    "codemirror": "^5.37.0",
     "prop-types": "^15.6.1",
     "react": "^16.3.2",
     "react-bootstrap": "^0.32.1",
+    "react-codemirror2": "^5.0.1",
     "react-dom": "^16.3.2",
     "react-helmet": "^5.2.0",
     "react-scripts": "1.1.4",

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -87,6 +87,42 @@ function query(sql) {
   });
 }
 
+function tables() {
+  return apiCall(`/tables`);
+}
+
+/* Returns an array in the form:
+[
+  {
+    "table": "refs",
+    "columns": [
+      {
+        "name": "repository_id",
+        "type": "TEXT"
+      },
+      ...
+    ]
+  },
+  ...
+]
+*/
+function schema() {
+  return tables()
+    .then(res =>
+      Promise.all(
+        res.data.map(e =>
+          query(`DESCRIBE TABLE ${e.table}`).then(tableRes => ({
+            table: e.table,
+            columns: tableRes.data
+          }))
+        )
+      )
+    )
+    .catch(err => Promise.reject(normalizeErrors(err)));
+}
+
 export default {
-  query
+  query,
+  tables,
+  schema
 };

--- a/frontend/src/components/QueryBox.js
+++ b/frontend/src/components/QueryBox.js
@@ -1,20 +1,82 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Row, Col, Button } from 'react-bootstrap';
+import { Controlled as CodeMirror } from 'react-codemirror2';
+
+import 'codemirror/lib/codemirror.css';
+import 'codemirror/mode/sql/sql';
+import 'codemirror/addon/display/placeholder';
+import 'codemirror/addon/edit/matchbrackets';
+import 'codemirror/addon/hint/show-hint.css';
+import 'codemirror/addon/hint/show-hint';
+import 'codemirror/addon/hint/sql-hint';
+
 import './QueryBox.less';
 
 class QueryBox extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      schema: undefined,
+      codeMirrorTables: {}
+    };
+  }
+
+  static getDerivedStateFromProps(nextProps, prevState) {
+    if (nextProps.schema === prevState.schema) {
+      return null;
+    }
+
+    return {
+      schema: nextProps.schema,
+      codeMirrorTables: QueryBox.schemaToCodeMirror(nextProps.schema)
+    };
+  }
+
+  static schemaToCodeMirror(schema) {
+    if (!schema) {
+      return {};
+    }
+
+    return schema.reduce(
+      (prevVal, currVal) => ({
+        ...prevVal,
+        [currVal.table]: currVal.columns.map(col => col.name)
+      }),
+      {}
+    );
+  }
+
   render() {
+    const { codeMirrorTables } = this.state;
+
+    const options = {
+      mode: 'text/x-mariadb',
+      smartIndent: true,
+      lineNumbers: true,
+      matchBrackets: true,
+      autofocus: true,
+      placeholder: 'Enter an SQL query',
+      extraKeys: {
+        'Ctrl-Space': 'autocomplete',
+        'Ctrl-Enter': () => this.props.handleSubmit()
+      },
+      hintOptions: {
+        tables: codeMirrorTables
+      }
+    };
+
     return (
       <div className="query-box">
         <Row>
           <Col xs={12}>
-            <textarea
-              autoFocus="true"
-              rows="7"
-              placeholder="Enter an SQL query"
+            <CodeMirror
               value={this.props.sql}
-              onChange={e => this.props.handleTextChange(e.target.value)}
+              options={options}
+              onBeforeChange={(editor, data, value) => {
+                this.props.handleTextChange(value);
+              }}
             />
           </Col>
         </Row>
@@ -36,6 +98,17 @@ class QueryBox extends Component {
 
 QueryBox.propTypes = {
   sql: PropTypes.string.isRequired,
+  schema: PropTypes.arrayOf(
+    PropTypes.shape({
+      table: PropTypes.string.isRequired,
+      columns: PropTypes.arrayOf(
+        PropTypes.shape({
+          name: PropTypes.string.isRequired,
+          type: PropTypes.string.isRequired
+        })
+      ).isRequired
+    })
+  ),
   enabled: PropTypes.bool,
   handleTextChange: PropTypes.func.isRequired,
   handleSubmit: PropTypes.func.isRequired

--- a/frontend/src/components/QueryBox.less
+++ b/frontend/src/components/QueryBox.less
@@ -2,11 +2,14 @@
   width: 100%;
 }
 
-textarea {
-  width: 100%;
-  font-family: monospace;
-}
-
 button {
   width: 100%;
+}
+
+.CodeMirror {
+  height: 150px;
+}
+
+.CodeMirror-empty {
+  color: dimgrey;
 }

--- a/frontend/src/components/TabbedResults.less
+++ b/frontend/src/components/TabbedResults.less
@@ -1,3 +1,4 @@
+
 .close {
   width: auto;
   margin-left: 1ex;
@@ -5,11 +6,6 @@
 
 .tab-content > .tab-pane {
   margin-top: 2em;
-}
-
-pre {
-  float: left;
-  max-width: 85%;
 }
 
 .query-row {

--- a/frontend/src/setupTests.js
+++ b/frontend/src/setupTests.js
@@ -11,3 +11,22 @@ global.localStorage = new LocalStorage(
 
 global.window = document.defaultView;
 global.window.localStorage = global.localStorage;
+
+// CodeMirror needs all of this in order to work.
+// see: https://discuss.codemirror.net/t/working-in-jsdom-or-node-js-natively/138/5
+global.document.body.createTextRange = function() {
+  return {
+    setEnd() {},
+    setStart() {},
+    getBoundingClientRect() {
+      return { right: 0 };
+    },
+    getClientRects() {
+      return {
+        length: 0,
+        left: 0,
+        right: 0
+      };
+    }
+  };
+};

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1524,6 +1524,10 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
+codemirror@^5.37.0:
+  version "5.37.0"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.37.0.tgz#c349b584e158f590277f26d37c2469a6bc538036"
+
 collection-visit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/collection-visit/-/collection-visit-1.0.0.tgz#4bc0373c164bc3291b4d368c829cf1a80a59dca0"
@@ -5746,6 +5750,10 @@ react-bootstrap@^0.32.1:
     react-transition-group "^2.0.0"
     uncontrollable "^4.1.0"
     warning "^3.0.0"
+
+react-codemirror2@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/react-codemirror2/-/react-codemirror2-5.0.1.tgz#81eb8e17bfe859633a6855a9ce40307914d42891"
 
 react-dev-utils@^5.0.1:
   version "5.0.1"


### PR DESCRIPTION
Fixes #20.

Besides syntax highlighting this PR also adds autocomplete. To do that, the schema is loaded when the application starts. Also the query can be executed with ctrl+enter.

![peek 2018-05-17 19-01](https://user-images.githubusercontent.com/1469173/40192639-436db80c-5a05-11e8-86a4-3be82bcd7711.gif)
