### PR TITLE
Add integration tests to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,16 @@ jobs:
         - make coverage
         - make validate-commit
     - script:
+      - docker run -d --name bblfshd --privileged --volume $HOME/bblfsh-drivers:/var/lib/bblfshd -p "9432:9432" bblfsh/bblfshd
+      - sleep 5
+      - docker exec -it bblfshd bblfshctl driver install go docker://bblfsh/go-driver:latest
+      - docker exec -it bblfshd bblfshctl driver install javascript docker://bblfsh/javascript-driver:latest
+      - mkdir $HOME/repos
+      - git clone https://github.com/src-d/gitbase-playground.git $HOME/repos/gitbase-playground
+      - docker run -d --name gitbase -p "3367:3306" -e "BBLFSH_ENDPOINT=bblfshd:9432" --volume $HOME/repos:/opt/repos --link bblfshd srcd/gitbase
+      - sleep 15
+      - GITBASEPG_DB_CONNECTION='gitbase@tcp(localhost:3367)/none' make back-test-integration
+    - script:
         - make packages
     # release to github
     - stage: release to github
@@ -60,3 +70,11 @@ jobs:
       script:
         - PKG_OS=linux make build
         - DOCKER_PUSH_LATEST=true make docker-push
+
+cache:
+  directories:
+    - $HOME/bblfsh-drivers/images
+
+before_cache:
+  # make bblfsh images readable
+  - sudo chmod -R 777 $HOME/bblfsh-drivers/images

--- a/server/handler/common_test.go
+++ b/server/handler/common_test.go
@@ -51,7 +51,7 @@ func (suite *HandlerSuite) TearDownSuite() {
 }
 
 type appConfig struct {
-	DBConn string `envconfig:"DB_CONNECTION" default:"root@tcp(localhost:3306)/none?maxAllowedPacket=4194304"`
+	DBConn string `envconfig:"DB_CONNECTION" default:"gitbase@tcp(localhost:3306)/none?maxAllowedPacket=4194304"`
 }
 
 func getDB(isIntegration bool) (service.SQLDB, error) {
@@ -85,11 +85,11 @@ func firstRow(require *require.Assertions, res *httptest.ResponseRecorder) map[s
 }
 
 func okResponse(require *require.Assertions, res *httptest.ResponseRecorder) {
-	require.Equal(http.StatusOK, res.Code)
-
 	var resBody serializer.Response
 	err := json.Unmarshal(res.Body.Bytes(), &resBody)
 	require.Nil(err)
+
+	require.Equal(http.StatusOK, res.Code, resBody.Errors)
 
 	require.Equal(res.Code, resBody.Status)
 	require.NotEmpty(resBody.Data)

--- a/server/handler/query_integration_test.go
+++ b/server/handler/query_integration_test.go
@@ -136,27 +136,3 @@ func (suite *QuerySuite) TestWrongLimit() {
 		})
 	}
 }
-
-// This test requires that gitbase can reach bblfshd and that it's serving the
-// repository https://github.com/src-d/gitbase-playground
-func (suite *QuerySuite) TestUastFunctions() {
-	req, _ := http.NewRequest("POST", "/query", strings.NewReader(
-		`{ "query": "SELECT hash, content, uast(content, 'go') as uast FROM blobs WHERE hash='fd30cea52792da5ece9156eea4022bdd87565633'" }`))
-
-	res := httptest.NewRecorder()
-	suite.handler.ServeHTTP(res, req)
-
-	if false {
-		okResponse(suite.Require(), res)
-
-		firstRow := firstRow(suite.Require(), res)
-		suite.IsType("string", firstRow["hash"])
-		suite.IsType("string", firstRow["content"])
-
-		var arr []interface{}
-		suite.IsType(arr, firstRow["uast"])
-
-		var jsonObj map[string]interface{}
-		suite.IsType(jsonObj, firstRow["uast"].([]interface{})[0])
-	}
-}

--- a/server/handler/query_uast_integration_test.go
+++ b/server/handler/query_uast_integration_test.go
@@ -28,6 +28,8 @@ func TestUastFunctions(t *testing.T) {
 	suite.Run(t, q)
 }
 
+// This test requires that gitbase can reach bblfshd and that it's serving the
+// repository https://github.com/src-d/gitbase-playground
 func (suite *QueryUast) TestUastFunctions() {
 	req, _ := http.NewRequest("POST", "/query", strings.NewReader(
 		`{ "query": "SELECT hash, content, uast(content, 'go') as uast FROM blobs WHERE hash='fd30cea52792da5ece9156eea4022bdd87565633'" }`))


### PR DESCRIPTION
Part of #32.

This PRs adds the already implemented integration tests to Travis CI.

The docker image `carlosms/bblfsh-ci-test:v0.0.1` contains the latest bblfshd image plus the recommended drivers (created with the [instructions here](https://github.com/bzz/ml-on-code/blob/master/images/README.md#create-bblfshd--drivers-image)). Before merging it would be better to host this image in the srcd organization.

It looks like the default gitbase port 3306 is in use in the travis image, that's why I'm using a different one.