### PR TITLE
Force pull before running latest image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ YARN := yarn --cwd $(FRONTEND_PATH)
 REMOVE := rm -rf
 MOVE := mv
 MKDIR := mkdir -p
-COMPOSE_UP := docker-compose
+COMPOSE := docker-compose
 
 # Default rule
 all:
@@ -69,9 +69,13 @@ build-path:
 
 serve: | front-build back-start
 
+compose-serve-latest:
+	$(COMPOSE) pull && \
+	GITBASEPG_REPOS_FOLDER=./repos $(COMPOSE) up --force-recreate
+
 compose-serve: | require-repos-folder front-dependencies build
 	GITBASEPG_REPOS_FOLDER=${GITBASEPG_REPOS_FOLDER} \
-		$(COMPOSE_UP) -f docker-compose.yml -f docker-compose.build.yml up --force-recreate --build
+		$(COMPOSE) -f docker-compose.yml -f docker-compose.build.yml up --force-recreate --build
 
 require-repos-folder:
 	@if [[ -z "$(GITBASEPG_REPOS_FOLDER)" ]]; then \

--- a/README.md
+++ b/README.md
@@ -27,13 +27,14 @@ Read [more about how to run bblfsh and gitbase dependencies](docs/quickstart.md)
 ### Run with Docker
 
 ```bash
-$ docker run -d
-    --publish 8080:8080
-    --link gitbase
-    --env GITBASEPG_ENV=dev
-    --env GITBASEPG_DB_CONNECTION="gitbase@tcp(gitbase:3306)/none?maxAllowedPacket=4194304"
-    --name gitbasePlayground
-    src-d/gitbase-playground:latest
+$ docker pull srcd/gitbase-playground:latest
+$ docker run -d \
+    --publish 8080:8080 \
+    --link gitbase \
+    --env GITBASEPG_ENV=dev \
+    --env GITBASEPG_DB_CONNECTION="gitbase@tcp(gitbase:3306)/none?maxAllowedPacket=4194304" \
+    --name gitbasePlayground \
+    srcd/gitbase-playground:latest
 ```
 
 

--- a/docs/quickstart-manually.md
+++ b/docs/quickstart-manually.md
@@ -46,6 +46,7 @@ $ docker run \
 Once bblfsh and gitbase are running and accessible, you can serve the playground:
 
 ```bash
+$ docker pull srcd/gitbase-playground:latest
 $ docker run -d \
     --publish 8080:8080 \
     --link gitbase \

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -35,6 +35,7 @@ Everytime you want to add a new repository to gitbase, the application should be
 Run the [latest released version of the frontend](https://hub.docker.com/r/srcd/gitbase-playground/tags/):
 
 ```bash
+$ docker-compose pull playground
 $ GITBASEPG_REPOS_FOLDER=./repos docker-compose up --force-recreate
 ```
 


### PR DESCRIPTION
Since [`docker-compose up` doesn't pull `:latest` image if it already exists locally](https://github.com/docker/compose/issues/3574) it is needed to pull it explicitly before running `docker-compose up`

As we were talking IRL I added it to the `Makefile` so it would be easier to run:
- `compose-serve-latest`: pulls `:latest` released image and serves it
- `compose-serve`: builds from current sources and serves it

Feel free to suggest any other name for `make` targets ;)