### PR TITLE
Integrate uast-viewer

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,8 @@
     "react-helmet": "^5.2.0",
     "react-scripts": "1.1.4",
     "react-split-pane": "^0.1.77",
-    "react-table": "^6.8.2"
+    "react-table": "^6.8.2",
+    "uast-viewer": "^0.0.2"
   },
   "scripts": {
     "start": "react-app-rewired start",
@@ -33,8 +34,8 @@
     "prettier": "^1.12.1",
     "react-app-rewire-less": "^2.1.1",
     "react-app-rewired": "^1.5.2",
-    "whatwg-url": "^6.4.1",
-    "react-test-renderer": "^16.4.0"
+    "react-test-renderer": "^16.4.0",
+    "whatwg-url": "^6.4.1"
   },
   "proxy": {
     "/query": {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -2,6 +2,8 @@ import React, { Component } from 'react';
 import { Helmet } from 'react-helmet';
 import { Grid, Row, Col, Modal } from 'react-bootstrap';
 import SplitPane from 'react-split-pane';
+import UASTViewer, { transformer } from 'uast-viewer';
+import 'uast-viewer/dist/default-theme.css';
 import Sidebar from './components/Sidebar';
 import QueryBox from './components/QueryBox';
 import TabbedResults from './components/TabbedResults';
@@ -125,7 +127,14 @@ FROM ( SELECT MONTH(committer_when) as month,
     this.setState({
       showModal: true,
       modalTitle: 'UAST',
-      modalContent: <pre>{JSON.stringify(uast, null, 2)}</pre>
+      modalContent:
+        // currently github returns only 1 item, UAST of the file
+        // but just in case if there is more or less we show it without viewer
+        uast.length === 1 ? (
+          <UASTViewer uast={transformer(uast[0])} />
+        ) : (
+          <pre>{uast}</pre>
+        )
     });
   }
 

--- a/frontend/src/App.less
+++ b/frontend/src/App.less
@@ -65,3 +65,16 @@ body {
         }
     }
 }
+
+// make modal window "fullscreen"
+// margins are hard-coded in bootstrap, so it's hard-coded here too
+.modal-body {
+    max-height: ~'calc(100vh - 80px)';
+    overflow-y: auto;
+}
+
+@media (min-width: @screen-sm-min) {
+    .modal-body {
+        max-height: ~'calc(100vh - 120px)';
+    }
+}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7021,6 +7021,10 @@ ua-parser-js@^0.7.9:
   version "0.7.18"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.18.tgz#a7bfd92f56edfb117083b69e31d2aa8882d4b1ed"
 
+uast-viewer@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/uast-viewer/-/uast-viewer-0.0.2.tgz#25dbd2649f51cff9380869d57c8edd813bb1e0b2"
+
 uglify-js@3.3.x, uglify-js@^3.0.13:
   version "3.3.23"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.3.23.tgz#48ea43e638364d18be292a6fdc2b5b7c35f239ab"


### PR DESCRIPTION
Fix: #45 

Based on #52

Currently, there is a warning
```
Warning: Failed prop type: Invalid prop `roles[0]` of type `number` supplied to `Roles`, expected `string`.
```
It will be fixed when #54 is merged.

<img width="1263" alt="screen shot 2018-06-05 at 12 38 25" src="https://user-images.githubusercontent.com/406916/40971284-65f46ac6-68bd-11e8-9a71-8f468c8562b8.png">
