### PR TITLE
Use debian instead of alpine for the docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
-FROM alpine:3.7
-ADD ./build/bin /bin
+FROM debian:stretch-slim
 
-RUN apk --update upgrade && \
-    apk add --no-cache ca-certificates
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends --no-install-suggests \
+  ca-certificates \
+  libxml2 \
+  && apt-get clean
+
+ADD ./build/bin /bin
 
 ENTRYPOINT ["/bin/gitbase-playground"]


### PR DESCRIPTION
The binary is dynamic since we added the bblfsh API client dependency, and it won't work in alpine anymore.

New Dockerfile based on the one we use in the [bblfsh dashboard](https://github.com/bblfsh/dashboard/blob/master/Dockerfile).