### PR TITLE
Edit tab titles

### DIFF
--- a/frontend/src/components/TabbedResults.less
+++ b/frontend/src/components/TabbedResults.less
@@ -3,6 +3,11 @@
     margin-left: 1ex;
 }
 
+.edit {
+    font-size: 14px;
+    line-height: 24px;
+}
+
 #tabbed-results {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
Fix: #72 

The name is scoped to the tabbed results component. Please let me know if it should be reflected in history too.

<img width="308" alt="screen shot 2018-06-12 at 16 07 53" src="https://user-images.githubusercontent.com/406916/41287084-10982fe2-6e5b-11e8-912a-1ad467b7b021.png">
<img width="346" alt="screen shot 2018-06-12 at 16 08 45" src="https://user-images.githubusercontent.com/406916/41287090-15f15ebe-6e5b-11e8-8dba-1666f3422c34.png">
