### PR TITLE
Add main style

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -20,6 +20,10 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>Gitbase Playground</title>
+
+    <!-- TODO @carlosms download and serve fonts from our server -->
+    <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro" rel="stylesheet">
+    <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/hack-font@3/build/web/hack.css">
   </head>
   <body>
     <noscript>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { Helmet } from 'react-helmet';
-import { Grid, Row, Col, Modal } from 'react-bootstrap';
+import { Grid, Row, Modal, Button } from 'react-bootstrap';
+import { bootstrapUtils } from 'react-bootstrap/lib/utils';
 import SplitPane from 'react-split-pane';
 import UASTViewer, { Editor, transformer } from 'uast-viewer';
 import 'uast-viewer/dist/default-theme.css';
@@ -276,7 +277,7 @@ FROM ( SELECT MONTH(committer_when) as month,
         <Helmet>
           <title>Gitbase Playground</title>
         </Helmet>
-        <Grid className="full-height" fluid={true}>
+        <Grid className="full-height app-grid" fluid={true}>
           <Row className="main-row full-height">
             <Sidebar
               schema={this.state.schema}
@@ -285,37 +286,25 @@ FROM ( SELECT MONTH(committer_when) as month,
             />
             <div className="full-height full-width">
               <SplitPane split="horizontal" defaultSize={250} minSize={100}>
-                <Grid className="full-height full-width">
-                  <Row className="query-box-row">
-                    <Col xs={12} className="full-height">
-                      <QueryBox
-                        sql={this.state.sql}
-                        schema={this.state.schema}
-                        resultMeta={this.state.lastResultMeta}
-                        handleTextChange={this.handleTextChange}
-                        handleSubmit={this.handleSubmit}
-                        exportUrl={api.queryExport(this.state.sql)}
-                      />
-                    </Col>
-                  </Row>
-                </Grid>
-                <Grid className="full-height full-width">
-                  <Row className="results-row">
-                    <Col xs={12} className="full-height">
-                      <TabbedResults
-                        results={results}
-                        history={history}
-                        handleRemoveResult={this.handleRemoveResult}
-                        handleEditQuery={this.handleTextChange}
-                        handleResetHistory={this.handleResetHistory}
-                        handleSetActiveResult={this.handleSetActiveResult}
-                        handleReload={this.handleReload}
-                        showCode={this.showCode}
-                        showUAST={this.showUAST}
-                      />
-                    </Col>
-                  </Row>
-                </Grid>
+                <QueryBox
+                  sql={this.state.sql}
+                  schema={this.state.schema}
+                  resultMeta={this.state.lastResultMeta}
+                  handleTextChange={this.handleTextChange}
+                  handleSubmit={this.handleSubmit}
+                  exportUrl={api.queryExport(this.state.sql)}
+                />
+                <TabbedResults
+                  results={results}
+                  history={history}
+                  handleRemoveResult={this.handleRemoveResult}
+                  handleEditQuery={this.handleTextChange}
+                  handleResetHistory={this.handleResetHistory}
+                  handleSetActiveResult={this.handleSetActiveResult}
+                  handleReload={this.handleReload}
+                  showCode={this.showCode}
+                  showUAST={this.showUAST}
+                />
               </SplitPane>
             </div>
           </Row>
@@ -334,5 +323,11 @@ FROM ( SELECT MONTH(committer_when) as month,
     );
   }
 }
+
+bootstrapUtils.addStyle(Button, 'gbpl-secondary');
+bootstrapUtils.addStyle(Button, 'gbpl-secondary-tint-2-link');
+bootstrapUtils.addStyle(Button, 'gbpl-tertiary');
+bootstrapUtils.addStyle(Button, 'gbpl-tertiary-tint-2-link');
+bootstrapUtils.addStyle(Button, 'gbpl-primary-tint-2');
 
 export default App;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -284,29 +284,27 @@ FROM ( SELECT MONTH(committer_when) as month,
               onTableClick={this.handleTableClick}
               onExampleClick={this.handleExampleClick}
             />
-            <div className="full-height full-width">
-              <SplitPane split="horizontal" defaultSize={250} minSize={100}>
-                <QueryBox
-                  sql={this.state.sql}
-                  schema={this.state.schema}
-                  resultMeta={this.state.lastResultMeta}
-                  handleTextChange={this.handleTextChange}
-                  handleSubmit={this.handleSubmit}
-                  exportUrl={api.queryExport(this.state.sql)}
-                />
-                <TabbedResults
-                  results={results}
-                  history={history}
-                  handleRemoveResult={this.handleRemoveResult}
-                  handleEditQuery={this.handleTextChange}
-                  handleResetHistory={this.handleResetHistory}
-                  handleSetActiveResult={this.handleSetActiveResult}
-                  handleReload={this.handleReload}
-                  showCode={this.showCode}
-                  showUAST={this.showUAST}
-                />
-              </SplitPane>
-            </div>
+            <SplitPane split="horizontal" defaultSize={250} minSize={100}>
+              <QueryBox
+                sql={this.state.sql}
+                schema={this.state.schema}
+                resultMeta={this.state.lastResultMeta}
+                handleTextChange={this.handleTextChange}
+                handleSubmit={this.handleSubmit}
+                exportUrl={api.queryExport(this.state.sql)}
+              />
+              <TabbedResults
+                results={results}
+                history={history}
+                handleRemoveResult={this.handleRemoveResult}
+                handleEditQuery={this.handleTextChange}
+                handleResetHistory={this.handleResetHistory}
+                handleSetActiveResult={this.handleSetActiveResult}
+                handleReload={this.handleReload}
+                showCode={this.showCode}
+                showUAST={this.showUAST}
+              />
+            </SplitPane>
           </Row>
         </Grid>
         <Modal

--- a/frontend/src/App.less
+++ b/frontend/src/App.less
@@ -1,4 +1,4 @@
-@import '../node_modules/bootstrap/less/variables.less';
+@import './variables.less';
 
 html,
 body,
@@ -11,12 +11,22 @@ body,
 body {
     max-height: 100%;
     overflow: hidden;
+    background-color: @primary-tint-4;
+    font-family: @regular-font;
+    font-size: 13px;
+    font-style: normal;
+    font-stretch: normal;
+    line-height: normal;
+    letter-spacing: normal;
+    color: @primary;
 }
 
 .app {
     height: 100%;
-    padding-top: 1em;
-    padding-bottom: 1em;
+
+    .app-grid {
+        padding-left: 0;
+    }
 }
 
 .full-height {
@@ -29,11 +39,11 @@ body {
 
 .main-row {
     display: flex;
+}
 
-    & > div {
-        margin-left: @grid-gutter-width / 2;
-        margin-right: @grid-gutter-width / 2;
-    }
+.no-spacing {
+    padding: 0;
+    margin: 0;
 }
 
 .query-box-row {
@@ -57,12 +67,9 @@ body {
     }
 
     .Resizer {
-        margin-top: 1em;
-        margin-bottom: 1em;
-        padding: 2px 0;
-
-        color: @gray;
-        background: @gray-lighter;
+        border-top: solid 1px @primary-tint-2;
+        border-bottom: solid 1px @primary-tint-2;
+        background-color: @query-results-block;
 
         cursor: row-resize;
 
@@ -70,7 +77,8 @@ body {
             display: block;
             content: '● ● ●';
             text-align: center;
-            line-height: 11px;
+            line-height: 13px;
+            font-size: 8px;
         }
     }
 }

--- a/frontend/src/App.less
+++ b/frontend/src/App.less
@@ -14,10 +14,7 @@ body {
     background-color: @primary-tint-4;
     font-family: @regular-font;
     font-size: 13px;
-    font-style: normal;
-    font-stretch: normal;
     line-height: normal;
-    letter-spacing: normal;
     color: @primary;
 }
 
@@ -88,6 +85,10 @@ body {
 .modal-body {
     height: ~'calc(100vh - 80px)';
     overflow-y: auto;
+
+    .CodeMirror {
+        height: 100%;
+    }
 }
 
 @media (min-width: @screen-sm-min) {

--- a/frontend/src/components/HistoryTable.js
+++ b/frontend/src/components/HistoryTable.js
@@ -43,7 +43,7 @@ class HistoryTable extends Component {
     return (
       <div className="history">
         <div className="toolbar">
-          <a onClick={handleReset}>Reset history</a>
+          <a onClick={handleReset}>reset history</a>
         </div>
         <ReactTable
           className="results-table"

--- a/frontend/src/components/HistoryTable.less
+++ b/frontend/src/components/HistoryTable.less
@@ -1,6 +1,20 @@
+@import '../variables.less';
+
 .history {
-    a:hover {
-        cursor: pointer;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+
+    a {
+        color: @tertiary-tint-2;
+        letter-spacing: 0.5px;
+        font-weight: @bold-font-weight;
+        text-decoration: underline;
+
+        &:hover {
+            cursor: pointer;
+            color: darken(@tertiary-tint-2, 10%);
+        }
     }
 
     .toolbar {

--- a/frontend/src/components/QueryBox.js
+++ b/frontend/src/components/QueryBox.js
@@ -75,40 +75,46 @@ class QueryBox extends Component {
     }
 
     return (
-      <div className="query-box">
-        <Row className="codemirror-row">
-          <Col xs={12} className="codemirror-col">
-            <CodeMirror
-              value={this.props.sql}
-              options={options}
-              onBeforeChange={(editor, data, value) => {
-                this.props.handleTextChange(value);
-              }}
-            />
-          </Col>
-        </Row>
-        <Row className="button-row">
-          <Col xs={6}>{meta}</Col>
-          <Col xs={3}>
-            <Button
-              className="pull-right"
-              disabled={!this.props.exportUrl}
-              href={this.props.exportUrl}
-              target="_blank"
-            >
-              EXPORT
-            </Button>
-          </Col>
-          <Col xs={3}>
-            <Button
-              className="pull-right"
-              disabled={this.props.enabled === false}
-              onClick={this.props.handleSubmit}
-            >
-              RUN
-            </Button>
-          </Col>
-        </Row>
+      <div className="query-box-padding full-height full-width">
+        <div className="query-box full-height full-width">
+          <Row className="codemirror-row no-spacing">
+            <Col xs={12} className="codemirror-col no-spacing">
+              <CodeMirror
+                value={this.props.sql}
+                options={options}
+                onBeforeChange={(editor, data, value) => {
+                  this.props.handleTextChange(value);
+                }}
+              />
+            </Col>
+          </Row>
+          <Row className="button-row">
+            <Col xs={6} className="meta-wrapper">
+              <span className="meta">{meta}</span>
+            </Col>
+            <Col xs={3}>
+              <Button
+                className="pull-right"
+                bsStyle="gbpl-secondary-tint-2-link"
+                disabled={!this.props.exportUrl}
+                href={this.props.exportUrl}
+                target="_blank"
+              >
+                EXPORT
+              </Button>
+            </Col>
+            <Col xs={3}>
+              <Button
+                className="pull-right"
+                bsStyle="gbpl-secondary"
+                disabled={this.props.enabled === false}
+                onClick={this.props.handleSubmit}
+              >
+                RUN QUERY
+              </Button>
+            </Col>
+          </Row>
+        </div>
       </div>
     );
   }

--- a/frontend/src/components/QueryBox.less
+++ b/frontend/src/components/QueryBox.less
@@ -49,12 +49,12 @@
     button {
         width: 100%;
     }
-}
 
-.CodeMirror {
-    height: 100%;
-}
+    .CodeMirror {
+        height: 100%;
+    }
 
-.CodeMirror-empty {
-    color: @gray-light;
+    .CodeMirror-empty {
+        color: @gray-light;
+    }
 }

--- a/frontend/src/components/QueryBox.less
+++ b/frontend/src/components/QueryBox.less
@@ -1,18 +1,41 @@
-@import '../../node_modules/bootstrap/less/variables.less';
+@import '../variables.less';
+
+.query-box-padding {
+    padding: @small-spacing;
+}
 
 .query-box {
     height: 100%;
     display: flex;
     flex-direction: column;
 
+    border: solid 1px @primary;
+    background-color: @query-results-block;
+
+    .meta-wrapper {
+        display: table;
+        height: 100%;
+
+        .meta {
+            display: table-cell;
+            vertical-align: middle;
+
+            font-size: 14px;
+        }
+    }
+
     .codemirror-row {
         flex-grow: 1;
         display: flex;
         overflow: hidden;
+        padding-top: 26px;
     }
 
     .button-row {
         flex: 0 0;
+        border-top: solid 1px @primary-tint-3;
+        padding: @big-spacing;
+        margin: 0;
     }
 
     .codemirror-col {

--- a/frontend/src/components/ResultsTable.js
+++ b/frontend/src/components/ResultsTable.js
@@ -19,12 +19,28 @@ class ResultsTable extends Component {
           case 'string':
             // assume any multiline string is code
             if (v.indexOf('\n') > -1) {
-              return <Button onClick={() => showCode(v)}>Code</Button>;
+              return (
+                <Button
+                  bsStyle="gbpl-tertiary"
+                  className="btn-compact"
+                  onClick={() => showCode(v)}
+                >
+                  Code
+                </Button>
+              );
             }
             return v;
           case 'object':
             // UAST column
-            return <Button onClick={() => showUAST(v)}>UAST</Button>;
+            return (
+              <Button
+                bsStyle="gbpl-tertiary"
+                className="btn-compact"
+                onClick={() => showUAST(v)}
+              >
+                UAST
+              </Button>
+            );
           default:
             return v;
         }

--- a/frontend/src/components/SampleQueries.less
+++ b/frontend/src/components/SampleQueries.less
@@ -1,21 +1,26 @@
+@import '../variables.less';
+
 .sample-queries {
     .title {
-        padding: 3px 0;
-        margin-bottom: 10px;
-        background: #ccc;
-
+        letter-spacing: 0.5px;
+        color: @primary;
         text-align: center;
         text-transform: uppercase;
+
+        font-size: 14px;
+
+        padding: 12px 0;
+        margin-bottom: 19px;
+
+        background-color: @query-examples-bock;
     }
 
     .query {
+        padding-left: @big-spacing;
         overflow: hidden;
         white-space: nowrap;
         text-overflow: ellipsis;
         cursor: pointer;
-
-        .glyphicon {
-            margin-right: 5px;
-        }
+        padding-right: 40px;
     }
 }

--- a/frontend/src/components/Schema.js
+++ b/frontend/src/components/Schema.js
@@ -21,7 +21,7 @@ class SchemaTable extends Component {
     const glyph = this.state.expanded ? 'minus' : 'plus';
 
     return (
-      <div className="schema-table">
+      <div className="schema-table list">
         <div className="name">
           <Glyphicon glyph={glyph} onClick={this.toggle} />
           <span onClick={() => onTableClick && onTableClick(table)}>
@@ -32,6 +32,7 @@ class SchemaTable extends Component {
           <div className="columns">
             {columns.map((c, i) => (
               <div key={i} className="column">
+                <Glyphicon glyph="align-justify" />
                 {c.name}
               </div>
             ))}

--- a/frontend/src/components/Schema.less
+++ b/frontend/src/components/Schema.less
@@ -1,13 +1,11 @@
+@import '../variables.less';
+
 .schema-table {
     .name {
         cursor: pointer;
-
-        .glyphicon {
-            margin-right: 5px;
-        }
     }
 
     .columns {
-        margin-left: 30px;
+        margin-left: @big-spacing;
     }
 }

--- a/frontend/src/components/Sidebar.js
+++ b/frontend/src/components/Sidebar.js
@@ -27,7 +27,7 @@ class Sidebar extends Component {
     return (
       <div className={`sidebar ${collapsed ? 'collapsed' : ''}`}>
         <div className="header">
-          <h3>{'{d}'} Gitbase Playground </h3>
+          <h3>gitbase playgroun{'{d}'}</h3>
           <Glyphicon onClick={this.handleToggle} glyph={togglerIcon} />
         </div>
         <div className="main">
@@ -36,35 +36,37 @@ class Sidebar extends Component {
             <SampleQueries onExampleClick={onExampleClick} />
           </SplitPane>
         </div>
-        <div className="footer">
-          <a
-            href="https://sourced.tech"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            source{'{d}'}
-          </a>
-          <a
-            href="https://github.com/src-d/gitbase"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            gitbase
-          </a>
-          <a
-            href="https://github.com/src-d/go-git"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            go-git
-          </a>
-          <a
-            href="https://doc.bblf.sh"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            babelfish
-          </a>
+        <div className="footer list">
+          <div>
+            <Glyphicon glyph="list" />
+            <a
+              href="https://github.com/src-d/go-git"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              go-git
+            </a>
+          </div>
+          <div>
+            <Glyphicon glyph="list" />
+            <a
+              href="https://doc.bblf.sh"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              babelfish
+            </a>
+          </div>
+          <div>
+            <Glyphicon glyph="list" />
+            <a
+              href="https://sourced.tech"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              source{'{d}'} © 2018
+            </a>
+          </div>
         </div>
       </div>
     );

--- a/frontend/src/components/Sidebar.less
+++ b/frontend/src/components/Sidebar.less
@@ -1,47 +1,69 @@
+@import '../variables.less';
+
 .sidebar {
     display: flex;
     flex-direction: column;
+    max-width: 290px;
 
+    padding-top: 10px;
+    padding-bottom: @big-spacing;
+    margin-bottom: 0px;
     min-height: 100%;
+    background-color: @primary-tint-3;
+    border-right: solid 1px @primary-tint-2;
 
     .header {
         display: flex;
-        flex: 0 0 24px;
+        flex: 0 0 auto;
 
-        margin: 0 0 10px 0;
-        padding: 0 0 10px 0;
+        margin: 0;
+        padding: @big-spacing 0 @big-spacing @big-spacing;
 
-        border-bottom: 1px solid #000;
+        color: @primary-tint-2;
 
         h3 {
+            font-size: 16px;
+            font-weight: @bold-font-weight;
+
             width: 100%;
 
             margin: 0;
-            padding: 0;
-
-            font-size: 16px;
-            font-weight: normal;
+            // padding: 0;
         }
 
         .glyphicon {
             cursor: pointer;
+            padding-right: @big-spacing;
+        }
+
+    }
+
+    .list {
+        line-height: 1.5;
+
+        .glyphicon {
+            margin-right: @small-spacing;
         }
     }
 
     .main {
         flex: 1 1;
-        margin-bottom: 10px;
+        margin-bottom: @small-spacing;
     }
 
     .footer {
-        flex: 0 0;
-
-        display: flex;
-        justify-content: space-between;
+        font-weight: @bold-font-weight;
+        padding-left: @big-spacing;
     }
 
-    .SplitPane .Resizer {
-        margin: 0;
+    .SplitPane {
+        .Resizer {
+            background-color: @primary-tint-3;
+        }
+
+        .Pane1 {
+            padding-left: @big-spacing;
+        }
     }
 
     &.collapsed {
@@ -49,10 +71,6 @@
         .main,
         .footer {
             display: none;
-        }
-
-        .header {
-            border-bottom: 0;
         }
     }
 }

--- a/frontend/src/components/Sidebar.less
+++ b/frontend/src/components/Sidebar.less
@@ -26,9 +26,7 @@
             font-weight: @bold-font-weight;
 
             width: 100%;
-
             margin: 0;
-            // padding: 0;
         }
 
         .glyphicon {

--- a/frontend/src/components/TabbedResults.js
+++ b/frontend/src/components/TabbedResults.js
@@ -29,7 +29,7 @@ class TabTitle extends Component {
   }
 
   render() {
-    const { tabKey } = this.props;
+    const { tabKey, active } = this.props;
     const { title, inEdit } = this.state;
 
     if (inEdit) {
@@ -37,6 +37,7 @@ class TabTitle extends Component {
         <div ref={this.ref}>
           <input
             type="text"
+            className="tab-title"
             value={title}
             onChange={e => {
               this.setState({ title: e.target.value });
@@ -56,20 +57,24 @@ class TabTitle extends Component {
       <div>
         <span className="tab-title">{title}</span>
         <Button
-          className="close"
-          onClick={() => {
-            this.props.handleRemoveResult(tabKey);
-          }}
-        >
-          <span aria-hidden="true">&times;</span>
-        </Button>
-        <Button
-          className="close edit"
+          className="btn-title"
+          bsStyle={active ? 'gbpl-tertiary' : 'gbpl-primary-tint-2'}
+          bsSize="xsmall"
           onClick={() => {
             this.handleStartEdit(tabKey);
           }}
         >
           <Glyphicon glyph="pencil" />
+        </Button>
+        <Button
+          className="btn-title"
+          bsStyle={active ? 'gbpl-tertiary' : 'gbpl-primary-tint-2'}
+          bsSize="xsmall"
+          onClick={() => {
+            this.props.handleRemoveResult(tabKey);
+          }}
+        >
+          <span aria-hidden="true">&times;</span>
         </Button>
       </div>
     );
@@ -78,6 +83,7 @@ class TabTitle extends Component {
 
 TabTitle.propTypes = {
   tabKey: PropTypes.any.isRequired,
+  active: PropTypes.bool.isRequired,
   title: PropTypes.string.isRequired,
   handleRemoveResult: PropTypes.func.isRequired
 };
@@ -124,91 +130,110 @@ class TabbedResults extends Component {
     const { showCode, showUAST, history } = this.props;
 
     return (
-      <Tabs
-        id="tabbed-results"
-        className="full-height"
-        activeKey={this.state.activeKey}
-        onSelect={this.handleSelect}
-      >
-        {Array.from(this.props.results.entries()).map(([key, query]) => {
-          let content = '';
-          if (key === this.state.activeKey) {
-            if (query.loading) {
-              content = (
-                <Row>
-                  <Col className="text-center loader-col" xs={12}>
-                    <Loader />
-                  </Col>
-                </Row>
-              );
-            } else if (query.errorMsg) {
-              content = (
-                <Row className="errors-row">
+      <div className="results-padding full-height full-width">
+        <Tabs
+          id="tabbed-results"
+          className="full-height"
+          activeKey={this.state.activeKey}
+          onSelect={this.handleSelect}
+        >
+          {Array.from(this.props.results.entries()).map(([key, query]) => {
+            let content = '';
+            if (key === this.state.activeKey) {
+              if (query.loading) {
+                content = (
+                  <Row>
+                    <Col className="text-center loader-col" xs={12}>
+                      <Loader />
+                    </Col>
+                  </Row>
+                );
+              } else if (query.errorMsg) {
+                content = (
+                  <Row className="errors-row">
+                    <Col xs={12}>
+                      <Alert bsStyle="danger">{query.errorMsg}</Alert>
+                    </Col>
+                  </Row>
+                );
+              } else if (query.response) {
+                content = (
+                  <ResultsTable
+                    response={query.response}
+                    showCode={showCode}
+                    showUAST={showUAST}
+                  />
+                );
+              } else {
+                content = (
+                  <Row>
+                    <Col xs={12} className="text-center">
+                      SUSPENDED TAB<br />
+                      <Button onClick={() => this.props.handleReload(key)}>
+                        Reload
+                      </Button>
+                    </Col>
+                  </Row>
+                );
+              }
+            }
+
+            return (
+              <Tab
+                key={key}
+                eventKey={key}
+                title={
+                  <TabTitle
+                    title={query.title || query.sql}
+                    tabKey={key}
+                    active={key === this.state.activeKey}
+                    handleRemoveResult={this.props.handleRemoveResult}
+                  />
+                }
+              >
+                <Row className="query-row">
                   <Col xs={12}>
-                    <Alert bsStyle="danger">{query.errorMsg}</Alert>
-                  </Col>
-                </Row>
-              );
-            } else if (query.response) {
-              content = (
-                <ResultsTable
-                  response={query.response}
-                  showCode={showCode}
-                  showUAST={showUAST}
-                />
-              );
-            } else {
-              content = (
-                <Row>
-                  <Col xs={12} className="text-center">
-                    SUSPENDED TAB<br />
-                    <Button onClick={() => this.props.handleReload(key)}>
-                      Reload
+                    <div className="query-text">
+                      <p>{query.sql}</p>
+                    </div>
+                    <Button
+                      className="edit-query"
+                      bsStyle="gbpl-tertiary-tint-2-link"
+                      onClick={() => this.props.handleEditQuery(query.sql)}
+                    >
+                      EDIT
                     </Button>
                   </Col>
                 </Row>
-              );
+                {content}
+              </Tab>
+            );
+          })}
+          <Tab
+            key="history"
+            eventKey="history"
+            title={
+              <div>
+                <Button
+                  className="btn-title btn-history"
+                  bsStyle="gbpl-primary-tint-2"
+                  bsSize="xsmall"
+                  disabled
+                >
+                  <Glyphicon glyph="time" className="history-icon" />
+                </Button>
+                <span className="tab-title">history</span>
+              </div>
             }
-          }
-
-          return (
-            <Tab
-              key={key}
-              eventKey={key}
-              title={
-                <TabTitle
-                  title={query.title || query.sql}
-                  tabKey={key}
-                  handleRemoveResult={this.props.handleRemoveResult}
-                />
-              }
-            >
-              <Row className="query-row">
-                <Col xs={12}>
-                  <div className="query-text">
-                    <p>{query.sql}</p>
-                  </div>
-                  <Button
-                    className="edit-query"
-                    bsStyle="link"
-                    onClick={() => this.props.handleEditQuery(query.sql)}
-                  >
-                    edit query
-                  </Button>
-                </Col>
-              </Row>
-              {content}
-            </Tab>
-          );
-        })}
-        <Tab key="history" eventKey="history" title="History">
-          <HistoryTable
-            items={history}
-            onOpenQuery={this.props.handleEditQuery}
-            handleReset={this.props.handleResetHistory}
-          />
-        </Tab>
-      </Tabs>
+          >
+            <HistoryTable
+              items={history}
+              onOpenQuery={this.props.handleEditQuery}
+              handleReset={this.props.handleResetHistory}
+            />
+          </Tab>
+        </Tabs>
+      </div>
     );
   }
 }

--- a/frontend/src/components/TabbedResults.js
+++ b/frontend/src/components/TabbedResults.js
@@ -213,15 +213,10 @@ class TabbedResults extends Component {
             key="history"
             eventKey="history"
             title={
-              <div>
-                <Button
-                  className="btn-title btn-history"
-                  bsStyle="gbpl-primary-tint-2"
-                  bsSize="xsmall"
-                  disabled
-                >
+              <div className="history-tab">
+                <span className="icon-bg">
                   <Glyphicon glyph="time" className="history-icon" />
-                </Button>
+                </span>
                 <span className="tab-title">history</span>
               </div>
             }

--- a/frontend/src/components/TabbedResults.less
+++ b/frontend/src/components/TabbedResults.less
@@ -1,6 +1,7 @@
-.close {
-    width: auto;
-    margin-left: 1ex;
+@import '../variables.less';
+
+.results-padding {
+    padding: @small-spacing;
 }
 
 .edit {
@@ -19,9 +20,13 @@
     display: flex;
     flex-direction: column;
 
+    background-color: @query-results-block;
+    border: solid 1px @primary;
+    border-top: 0px;
+
     > .tab-pane {
         flex: 1 1 auto;
-        padding-top: 2em;
+        padding: @big-spacing;
 
         &[aria-hidden='false'] {
             display: flex;
@@ -35,7 +40,8 @@
 
     .query-text {
         white-space: pre;
-        font-family: monospace;
+        font-family: @monospace-font;
+        color: @secondary-tint-2;
         float: left;
         max-width: 85%;
         overflow: auto;
@@ -47,12 +53,30 @@ button.edit-query {
     float: left;
     padding-top: 0px;
     margin-left: 1ex;
+    border-top: 0px;
 }
 
 .tab-title {
     width: 150px;
+    height: @btn-title-size;
+    vertical-align: middle;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
     display: inline-block;
+    font-family: @monospace-font;
+    font-weight: @bold-font-weight;
+}
+
+.nav-tabs {
+    > li:last-child {
+        float: right;
+    }
+}
+
+.btn-history {
+    margin-left: 0 !important;
+    margin-right: 1ex !important;
+    cursor: default !important;
+    opacity: unset !important;
 }

--- a/frontend/src/components/TabbedResults.less
+++ b/frontend/src/components/TabbedResults.less
@@ -4,79 +4,77 @@
     padding: @small-spacing;
 }
 
-.edit {
-    font-size: 14px;
-    line-height: 24px;
-}
-
 #tabbed-results {
     display: flex;
     flex-direction: column;
-}
 
-.tab-content {
-    flex: 1 1 auto;
-
-    display: flex;
-    flex-direction: column;
-
-    background-color: @query-results-block;
-    border: solid 1px @primary;
-    border-top: 0px;
-
-    > .tab-pane {
+    .tab-content {
         flex: 1 1 auto;
-        padding: @big-spacing;
 
-        &[aria-hidden='false'] {
-            display: flex;
-            flex-direction: column;
+        display: flex;
+        flex-direction: column;
+
+        background-color: @query-results-block;
+        border: solid 1px @primary;
+        border-top: 0px;
+
+        > .tab-pane {
+            flex: 1 1 auto;
+            padding: @big-spacing;
+
+            &[aria-hidden='false'] {
+                display: flex;
+                flex-direction: column;
+            }
         }
     }
-}
 
-.query-row {
-    margin-bottom: 2em;
+    .query-row {
+        margin-bottom: 2em;
 
-    .query-text {
-        white-space: pre;
-        font-family: @monospace-font;
-        color: @secondary-tint-2;
+        .query-text {
+            white-space: pre;
+            font-family: @monospace-font;
+            color: @secondary-tint-2;
+            float: left;
+            max-width: 85%;
+            overflow: auto;
+        }
+    }
+
+    button.edit-query {
+        width: auto;
         float: left;
-        max-width: 85%;
-        overflow: auto;
+        padding-top: 0px;
+        margin-left: 1ex;
+        border-top: 0px;
     }
-}
 
-button.edit-query {
-    width: auto;
-    float: left;
-    padding-top: 0px;
-    margin-left: 1ex;
-    border-top: 0px;
-}
-
-.tab-title {
-    width: 150px;
-    height: @btn-title-size;
-    vertical-align: middle;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    display: inline-block;
-    font-family: @monospace-font;
-    font-weight: @bold-font-weight;
-}
-
-.nav-tabs {
-    > li:last-child {
-        float: right;
+    .tab-title {
+        width: 150px;
+        height: @btn-title-size;
+        vertical-align: middle;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        display: inline-block;
+        font-family: @monospace-font;
+        font-weight: @bold-font-weight;
     }
-}
 
-.btn-history {
-    margin-left: 0 !important;
-    margin-right: 1ex !important;
-    cursor: default !important;
-    opacity: unset !important;
+    .nav-tabs {
+        > li:last-child {
+            float: right;
+        }
+    }
+
+    .history-tab .icon-bg {
+        .btn-title;
+        .btn;
+        .btn-xs;
+        .btn-gbpl-primary-tint-2;
+
+        margin-left: 0;
+        margin-right: 1ex;
+    }
 }

--- a/frontend/src/components/__snapshots__/ResultsTable.test.js.snap
+++ b/frontend/src/components/__snapshots__/ResultsTable.test.js.snap
@@ -117,7 +117,7 @@ exports[`ResultsTable text with new lines should be shown as code 1`] = `
             }
           >
             <button
-              className="btn btn-default"
+              className="btn-compact btn btn-gbpl-tertiary"
               disabled={false}
               onClick={[Function]}
               type="button"

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import 'bootstrap/dist/css/bootstrap.css';
-import './override.less';
-import './index.less';
+import './variables.less';
 import App from './App';
 
 ReactDOM.render(<App />, document.getElementById('root'));

--- a/frontend/src/index.less
+++ b/frontend/src/index.less
@@ -1,5 +1,0 @@
-body {
-  margin: 0;
-  padding: 0;
-  font-family: sans-serif;
-}

--- a/frontend/src/override.less
+++ b/frontend/src/override.less
@@ -1,1 +1,0 @@
-// Placeholder file to add LESS styles

--- a/frontend/src/variables.less
+++ b/frontend/src/variables.less
@@ -1,0 +1,159 @@
+@import '../node_modules/bootstrap/less/bootstrap.less';
+
+//=== Colors
+@primary:           #1b78b7;
+@primary-tint-2:    #76aed3;
+@primary-tint-3:    #e8f1f7;
+@primary-tint-4:    #f5f9fb;
+
+@secondary:         #4ecc7b;
+@secondary-tint-2:  #368e56;
+
+@tertiary:          #ffba34;
+@tertiary-tint-2:   #e59200;
+
+@dark-text:         #112a3c;
+@white-text:        #fff;
+
+@query-results-block: #ffffff;
+@query-examples-bock: rgba(118, 174, 211, 0.2);
+
+//=== Spacing
+@big-spacing: 26px;
+@small-spacing: 10px;
+@tabs-spacing: 8px;
+
+//=== Fonts
+@bold-font-weight: 600;
+@monospace-font: Hack, monospace;
+@regular-font: 'Source Sans Pro', sans-serif;
+
+//=== Buttons
+@btn-font-weight: @bold-font-weight;
+
+.button-link-variant(@color) {
+    &:hover {
+        color: darken(@color, 10%);
+    }
+}
+
+// bsStyle gbpl-secondary: green background
+@btn-gbpl-secondary-color:  @white-text;
+@btn-gbpl-secondary-bg:     @secondary;
+@btn-gbpl-secondary-border: @btn-gbpl-secondary-bg;
+
+.btn-gbpl-secondary {
+    .button-variant(@btn-gbpl-secondary-color; @btn-gbpl-secondary-bg; @btn-gbpl-secondary-border);
+}
+
+// bsStyle gbpl-secondary-tint-2-link: green text, no background
+@btn-gbpl-secondary-tint-2-link-color:  @secondary-tint-2;
+@btn-gbpl-secondary-tint-2-link-bg:     transparent;
+@btn-gbpl-secondary-tint-2-link-border: @btn-gbpl-secondary-tint-2-link-bg;
+
+.btn-gbpl-secondary-tint-2-link {
+    .button-variant(@btn-gbpl-secondary-tint-2-link-color; @btn-gbpl-secondary-tint-2-link-bg; @btn-gbpl-secondary-tint-2-link-border);
+    .button-link-variant(@btn-gbpl-secondary-tint-2-link-color);
+}
+
+// bsStyle gbpl-tertiary: orange background
+@btn-gbpl-tertiary-color:     @white-text;
+@btn-gbpl-tertiary-bg:        @tertiary;
+@btn-gbpl-tertiary-border:    @btn-gbpl-tertiary-bg;
+
+.btn-gbpl-tertiary {
+    .button-variant(@btn-gbpl-tertiary-color; @btn-gbpl-tertiary-bg; @btn-gbpl-tertiary-border);
+}
+
+// bsStyle gbpl-tertiary-tint-2: orange text, no background
+@btn-gbpl-tertiary-tint-2-link-color:     @tertiary-tint-2;
+@btn-gbpl-tertiary-tint-2-link-bg:        transparent;
+@btn-gbpl-tertiary-tint-2-link-border:    @btn-gbpl-tertiary-tint-2-link-bg;
+
+.btn-gbpl-tertiary-tint-2-link {
+    .button-variant(@btn-gbpl-tertiary-tint-2-link-color; @btn-gbpl-tertiary-tint-2-link-bg; @btn-gbpl-tertiary-tint-2-link-border);
+    .button-link-variant(@btn-gbpl-tertiary-tint-2-link-color);
+}
+
+// bsStyle gbpl-primary-tint-2: blue background
+@btn-gbpl-primary-tint-2-color:     @white-text;
+@btn-gbpl-primary-tint-2-bg:        @primary-tint-2;
+@btn-gbpl-primary-tint-2-border:    @btn-gbpl-primary-tint-2-bg;
+
+.btn-gbpl-primary-tint-2 {
+    .button-variant(@btn-gbpl-primary-tint-2-color; @btn-gbpl-primary-tint-2-bg; @btn-gbpl-primary-tint-2-border);
+}
+
+// Allows for customizing button radius independently from global border radius
+@btn-border-radius-base:  100px;
+@btn-border-radius-large: 100px;
+@btn-border-radius-small: 100px;
+
+.btn {
+    letter-spacing: 0.6px;
+}
+
+// Less height, to be used inside the tables
+.btn-compact {
+    padding-top: 3px;
+    padding-bottom: 3px;
+}
+
+//=== Tabs
+@nav-link-padding: @tabs-spacing 15px;
+@nav-tabs-border-color: @primary;
+@nav-tabs-link-hover-border-color: @primary;
+@nav-tabs-active-link-hover-border-color: @primary;
+
+@border-radius-base: @tabs-spacing;
+@border-radius-large: @tabs-spacing;
+@border-radius-small: @tabs-spacing;
+
+.nav-tabs {
+    > li {
+        margin-top: @tabs-spacing;
+
+        // Actual tabs (as links)
+        > a {
+            color: @dark-text;
+            margin-right: @tabs-spacing;
+            border: 1px solid @primary;
+            background-color: @primary-tint-3;
+            &:hover {
+                background-color: darken(@primary-tint-3, 10%);
+            }
+        }
+
+        // Active state, and its :hover to override normal :hover
+        &.active {
+            margin-top: 0px;
+
+            > a {
+                &,
+                &:hover,
+                &:focus {
+                    padding-top: 8px + @tabs-spacing;
+
+                    color: @dark-text;
+                    background-color: @nav-tabs-active-link-hover-bg;
+                    border: 1px solid @nav-tabs-active-link-hover-border-color;
+                    border-bottom-color: transparent;
+                    cursor: default;
+                }
+            }
+        }
+    }
+    // pulling this in mainly for less shorthand
+    &.nav-justified {
+        .nav-justified();
+        .nav-tabs-justified();
+    }
+}
+
+@btn-title-size: 22px;
+
+.btn-title {
+    margin-left: 1ex;
+    height: @btn-title-size;
+    width: @btn-title-size;
+}


### PR DESCRIPTION
Part of #44.

This PR adds the main styles of the design spec.
In a few places where I needed a hover effect I've chosen to set the color to 10% darker of the base color, to keep it in line with the default button hover effect.

Missing things that I'd prefer to do in separate PRs:
- Style for the CodeMirror component (main input box)
- Style for React Table (results and history tables)
- Use design spec icons instead of bootstrap glyphicons
- I left a comment in `index.html` to download and serve the fonts locally, I assume this is preferable. Thoughts on this?

![issue-44](https://user-images.githubusercontent.com/1469173/41344256-e89cb00c-6f00-11e8-968e-71691566b22b.png)

cc: @ricardobaeta 