### PR TITLE
No cache for index.html

### DIFF
--- a/server/handler/static_files.go
+++ b/server/handler/static_files.go
@@ -73,6 +73,8 @@ func (s *Static) ServeIndexHTML(initialState interface{}) http.HandlerFunc {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
+
+		w.Header().Add("Cache-Control", "no-cache, no-store, must-revalidate")
 		b = bytes.Replace(b, []byte(serverValuesPlaceholder), bData, 1)
 		s.serveAsset(w, r, filepath, b)
 	}


### PR DESCRIPTION
Try to fix #70

The header is set as [No cache storage at all](https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching).