### PR TITLE
Set min sizes

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -284,7 +284,12 @@ FROM ( SELECT MONTH(committer_when) as month,
               onTableClick={this.handleTableClick}
               onExampleClick={this.handleExampleClick}
             />
-            <SplitPane split="horizontal" defaultSize={250} minSize={100}>
+            <SplitPane
+              className="main-split"
+              split="horizontal"
+              defaultSize={250}
+              minSize={175}
+            >
               <QueryBox
                 sql={this.state.sql}
                 schema={this.state.schema}

--- a/frontend/src/App.less
+++ b/frontend/src/App.less
@@ -10,7 +10,6 @@ body,
 
 body {
     max-height: 100%;
-    overflow: hidden;
     background-color: @primary-tint-4;
     font-family: @regular-font;
     font-size: 13px;
@@ -77,6 +76,10 @@ body {
             line-height: 13px;
             font-size: 8px;
         }
+    }
+
+    &.main-split {
+        min-width: 700px;
     }
 }
 


### PR DESCRIPTION
Part of #44.

This PR adds 2 commits:
- Set a sensible resize limit for the current query box contents
- Sets a min width for the main panel. Our current design does not work well for small devices, with this change at least you can scroll horizontally and still see all the information.

![a](https://user-images.githubusercontent.com/1469173/41428351-1a19d4de-700a-11e8-807e-de7b24a39d0e.png)

