### PR TITLE
Set style for the SQL query input

### DIFF
--- a/frontend/src/components/QueryBox.js
+++ b/frontend/src/components/QueryBox.js
@@ -55,7 +55,7 @@ class QueryBox extends Component {
     const options = {
       mode: 'text/x-mariadb',
       smartIndent: true,
-      lineNumbers: true,
+      lineNumbers: false,
       matchBrackets: true,
       autofocus: true,
       placeholder: 'Enter an SQL query',

--- a/frontend/src/components/QueryBox.less
+++ b/frontend/src/components/QueryBox.less
@@ -28,7 +28,8 @@
         flex-grow: 1;
         display: flex;
         overflow: hidden;
-        padding-top: 26px;
+        padding-top: 22px;
+        padding-left: @big-spacing;
     }
 
     .button-row {
@@ -52,6 +53,14 @@
 
     .CodeMirror {
         height: 100%;
+        font-family: @monospace-font;
+        font-size: 16px;
+        font-weight: bold;
+
+        .CodeMirror-gutters {
+            border-right: 0;
+            background-color: unset;
+        }
     }
 
     .CodeMirror-empty {


### PR DESCRIPTION
Part of #44.

This PR styles the SQL query input, setting the font, margins, and removing the line numbers gutter.

The `CodeMirror-gutters` style removes the gray background fron the line numbers gutter. Even if we don't use it, with this change the style matches and it can be enabled quicker at any moment.

![a](https://user-images.githubusercontent.com/1469173/41528724-23862372-72eb-11e8-814f-e9e2852dd3e2.png)
