### PR TITLE
Fix query and edit button misalignment

### DIFF
--- a/frontend/src/components/TabbedResults.less
+++ b/frontend/src/components/TabbedResults.less
@@ -32,6 +32,10 @@
     .query-row {
         margin-bottom: 2em;
 
+        .query-text, .edit-query {
+            line-height: 16px;
+        }
+
         .query-text {
             white-space: pre;
             font-family: @monospace-font;
@@ -40,14 +44,14 @@
             max-width: 85%;
             overflow: auto;
         }
-    }
 
-    button.edit-query {
-        width: auto;
-        float: left;
-        padding-top: 0px;
-        margin-left: 1ex;
-        border-top: 0px;
+        .edit-query {
+            width: auto;
+            float: left;
+            padding-top: 0px;
+            margin-left: 1ex;
+            border-top: 0px;
+        }
     }
 
     button.reload {


### PR DESCRIPTION
Part of #44.

The EDIT button inside the query results is misaligned with the SQL query, because they use different font family and size. With a fixed line-height both fonts align at the baseline.

![a](https://user-images.githubusercontent.com/1469173/41464923-50050784-709c-11e8-97f2-44a8de87d2fc.png)
