### PR TITLE
Add autofocus to tab title input

### DIFF
--- a/frontend/src/components/DivTabs.js
+++ b/frontend/src/components/DivTabs.js
@@ -1,0 +1,155 @@
+/* eslint-disable */
+
+/*
+Copy-past from react-bootstrap
+We can't just extend original component and redefine renderTab method because it exports uncontrollable HOC.
+
+We need to use <div> instead of <a> as tab titles due to Firefox behaviour of <input> inside <a>.
+It raise onBlur event on click. Example: http://jsfiddle.net/bc0u9hrq/5/
+*/
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import requiredForA11y from 'prop-types-extra/lib/isRequiredForA11y';
+import uncontrollable from 'uncontrollable';
+
+import {
+  Nav,
+  NavItem,
+  TabContainer as UncontrolledTabContainer,
+  TabContent
+} from 'react-bootstrap';
+import { bsClass as setBsClass } from 'react-bootstrap/lib/utils/bootstrapUtils';
+import ValidComponentChildren from 'react-bootstrap/lib/utils/ValidComponentChildren';
+
+const TabContainer = UncontrolledTabContainer.ControlledComponent;
+
+const propTypes = {
+  /**
+   * Mark the Tab with a matching `eventKey` as active.
+   *
+   * @controllable onSelect
+   */
+  activeKey: PropTypes.any,
+
+  /**
+   * Navigation style
+   */
+  bsStyle: PropTypes.oneOf(['tabs', 'pills']),
+
+  animation: PropTypes.bool,
+
+  id: requiredForA11y(
+    PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  ),
+
+  /**
+   * Callback fired when a Tab is selected.
+   *
+   * ```js
+   * function (
+   *   Any eventKey,
+   *   SyntheticEvent event?
+   * )
+   * ```
+   *
+   * @controllable activeKey
+   */
+  onSelect: PropTypes.func,
+
+  /**
+   * Wait until the first "enter" transition to mount tabs (add them to the DOM)
+   */
+  mountOnEnter: PropTypes.bool,
+
+  /**
+   * Unmount tabs (remove it from the DOM) when it is no longer visible
+   */
+  unmountOnExit: PropTypes.bool
+};
+
+const defaultProps = {
+  bsStyle: 'tabs',
+  animation: true,
+  mountOnEnter: false,
+  unmountOnExit: false
+};
+
+function getDefaultActiveKey(children) {
+  let defaultActiveKey;
+  ValidComponentChildren.forEach(children, child => {
+    if (defaultActiveKey == null) {
+      defaultActiveKey = child.props.eventKey;
+    }
+  });
+
+  return defaultActiveKey;
+}
+
+class DivTabs extends React.Component {
+  renderTab(child) {
+    const { title, eventKey, disabled, tabClassName } = child.props;
+    if (title == null) {
+      return null;
+    }
+
+    return (
+      <NavItem
+        eventKey={eventKey}
+        disabled={disabled}
+        className={tabClassName}
+        componentClass="div"
+      >
+        {title}
+      </NavItem>
+    );
+  }
+
+  render() {
+    const {
+      id,
+      onSelect,
+      animation,
+      mountOnEnter,
+      unmountOnExit,
+      bsClass,
+      className,
+      style,
+      children,
+      activeKey = getDefaultActiveKey(children),
+      ...props
+    } = this.props;
+
+    return (
+      <TabContainer
+        id={id}
+        activeKey={activeKey}
+        onSelect={onSelect}
+        className={className}
+        style={style}
+      >
+        <div>
+          <Nav {...props} role="tablist">
+            {ValidComponentChildren.map(children, this.renderTab)}
+          </Nav>
+
+          <TabContent
+            bsClass={bsClass}
+            animation={animation}
+            mountOnEnter={mountOnEnter}
+            unmountOnExit={unmountOnExit}
+          >
+            {children}
+          </TabContent>
+        </div>
+      </TabContainer>
+    );
+  }
+}
+
+DivTabs.propTypes = propTypes;
+DivTabs.defaultProps = defaultProps;
+
+setBsClass('tab', DivTabs);
+
+export default uncontrollable(DivTabs, { activeKey: 'onSelect' });

--- a/frontend/src/components/TabbedResults.js
+++ b/frontend/src/components/TabbedResults.js
@@ -1,6 +1,7 @@
 import React, { Component, Fragment } from 'react';
-import { Row, Col, Alert, Tabs, Tab, Button, Glyphicon } from 'react-bootstrap';
+import { Row, Col, Alert, Tab, Button, Glyphicon } from 'react-bootstrap';
 import PropTypes from 'prop-types';
+import DivTabs from './DivTabs';
 import ResultsTable from './ResultsTable';
 import HistoryTable from './HistoryTable';
 import Loader from './Loader';
@@ -18,6 +19,9 @@ class TabTitle extends Component {
 
     this.handleStartEdit = this.handleStartEdit.bind(this);
     this.handleEndEdit = this.handleEndEdit.bind(this);
+    this.handleChange = this.handleChange.bind(this);
+    this.handleKeyPress = this.handleKeyPress.bind(this);
+    this.handleBlur = this.handleBlur.bind(this);
   }
 
   handleStartEdit() {
@@ -28,6 +32,20 @@ class TabTitle extends Component {
     this.setState({ inEdit: false });
   }
 
+  handleChange(e) {
+    this.setState({ title: e.target.value });
+  }
+
+  handleKeyPress(e) {
+    if (e.key === 'Enter') {
+      this.handleEndEdit();
+    }
+  }
+
+  handleBlur() {
+    this.handleEndEdit();
+  }
+
   render() {
     const { tabKey, active } = this.props;
     const { title, inEdit } = this.state;
@@ -36,18 +54,15 @@ class TabTitle extends Component {
       return (
         <div ref={this.ref}>
           <input
+            autoFocus
             type="text"
             className="tab-title"
             value={title}
-            onChange={e => {
-              this.setState({ title: e.target.value });
-            }}
-            onKeyPress={e => {
-              if (e.key === 'Enter') {
-                this.handleEndEdit();
-              }
-            }}
-            onBlur={this.handleEndEdit}
+            onChange={this.handleChange}
+            onKeyPress={this.handleKeyPress}
+            /* disable handlers of tab components */
+            onKeyDown={e => e.stopPropagation()}
+            onBlur={this.handleBlur}
           />
         </div>
       );
@@ -131,7 +146,7 @@ class TabbedResults extends Component {
 
     return (
       <div className="results-padding full-height full-width">
-        <Tabs
+        <DivTabs
           id="tabbed-results"
           className="full-height"
           activeKey={this.state.activeKey}
@@ -240,7 +255,7 @@ class TabbedResults extends Component {
               />
             </Tab>
           )}
-        </Tabs>
+        </DivTabs>
       </div>
     );
   }

--- a/frontend/src/variables.less
+++ b/frontend/src/variables.less
@@ -116,13 +116,18 @@
         margin-top: @tabs-spacing;
 
         // Actual tabs (as links)
-        > a {
+        > a, > div {
             color: @dark-text;
+            padding: @nav-link-padding;
             margin-right: @tabs-spacing;
+            line-height: @line-height-base;
             border: 1px solid @primary;
+            border-radius: @border-radius-base @border-radius-base 0 0;
             background-color: @primary-tint-3;
+            cursor: pointer;
             &:hover {
                 background-color: darken(@primary-tint-3, 10%);
+                outline: none;
             }
         }
 
@@ -130,7 +135,7 @@
         &.active {
             margin-top: 0px;
 
-            > a {
+            > a, > div {
                 &,
                 &:hover,
                 &:focus {
@@ -141,6 +146,7 @@
                     border: 1px solid @nav-tabs-active-link-hover-border-color;
                     border-bottom-color: transparent;
                     cursor: default;
+                    outline: none;
                 }
             }
         }


### PR DESCRIPTION
Fix first 2 points in #97

The "space" problem comes from here: https://github.com/react-bootstrap/react-bootstrap/blob/master/src/SafeAnchor.js#L61
Arrows problem comes from here: https://github.com/react-bootstrap/react-bootstrap/blob/master/src/Nav.js#L238

We can fix it by inheriting bootstrap components and disable handlers when user clicked "edit".
Please let me know if you are ok with such solution. (I'll implement in separate PR)