### PR TITLE
Set colors in history table

### DIFF
--- a/frontend/src/components/HistoryTable.js
+++ b/frontend/src/components/HistoryTable.js
@@ -16,13 +16,29 @@ class HistoryTable extends Component {
         accessor: row => {
           switch (row.status) {
             case STATUS_SUCCESS:
-              return `Query ran in ${row.elapsedTime / 1000}sec`;
+              return (
+                <span className="history-log history-stat-success">
+                  Query ran in {row.elapsedTime / 1000}s
+                </span>
+              );
             case STATUS_ERROR:
-              return `Query failed - ${row.errorMsg}`;
+              return (
+                <span className="history-log history-stat-error">
+                  Query failed - {row.errorMsg}
+                </span>
+              );
             case STATUS_LOADING:
-              return 'Query is running';
+              return (
+                <span className="history-log history-stat-loading">
+                  Query is running
+                </span>
+              );
             default:
-              return 'unknown status';
+              return (
+                <span className="history-log history-stat-unknown">
+                  Unknown status
+                </span>
+              );
           }
         }
       },

--- a/frontend/src/components/HistoryTable.less
+++ b/frontend/src/components/HistoryTable.less
@@ -22,4 +22,14 @@
 
         text-align: right;
     }
+
+    .history-log {
+        &.history-stat-error {
+            color: @error-text;
+        }
+
+        &.history-stat-success {
+            color: @secondary-tint-2;
+        }
+    }
 }

--- a/frontend/src/variables.less
+++ b/frontend/src/variables.less
@@ -18,6 +18,8 @@
 @query-results-block: #ffffff;
 @query-examples-bock: rgba(118, 174, 211, 0.2);
 
+@error-text: #e4415a;
+
 //=== Spacing
 @big-spacing: 26px;
 @small-spacing: 10px;


### PR DESCRIPTION
Part of #44.

Sets colors for success & failure messages in the history table.

![a](https://user-images.githubusercontent.com/1469173/41470120-f0d6fd9e-70af-11e8-863e-77490960c20d.png)
