### PR TITLE
Fix commit_parents showing as UAST

### DIFF
--- a/frontend/src/components/ResultsTable.js
+++ b/frontend/src/components/ResultsTable.js
@@ -12,7 +12,13 @@ class ResultsTable extends Component {
       Header: col,
       id: col,
       accessor: row => {
-        const v = row[col];
+        let v = row[col];
+
+        // Array of hashes to string
+        if (Array.isArray(v) && v.every(e => typeof e === 'string')) {
+          v = v.join('\n');
+        }
+
         switch (typeof v) {
           case 'boolean':
             return v.toString();


### PR DESCRIPTION
Fix #94.

A commit with one parent shows the hash in the table cell, with more than one parent the 'code' viewer is used.