### PR TITLE
Fix history tab hover color

### DIFF
--- a/frontend/src/components/TabbedResults.js
+++ b/frontend/src/components/TabbedResults.js
@@ -223,7 +223,7 @@ class TabbedResults extends Component {
             <Tab
               key="history"
               eventKey="history"
-              tabClassName="history"
+              tabClassName="history-tab-title"
               title={
                 <div className="history-tab">
                   <span className="icon-bg">

--- a/frontend/src/components/TabbedResults.less
+++ b/frontend/src/components/TabbedResults.less
@@ -70,7 +70,7 @@
         font-weight: @bold-font-weight;
     }
 
-    li.history {
+    li.history-tab-title {
         float: right;
     }
 


### PR DESCRIPTION
Fix a bug introduced in #112, repeated `.history` class name.