### PR TITLE
Size tweaks

### DIFF
--- a/frontend/src/components/QueryBox.js
+++ b/frontend/src/components/QueryBox.js
@@ -89,12 +89,11 @@ class QueryBox extends Component {
             </Col>
           </Row>
           <Row className="button-row">
-            <Col xs={6} className="meta-wrapper">
+            <Col xs={7} className="meta-wrapper no-spacing">
               <span className="meta">{meta}</span>
             </Col>
-            <Col xs={3}>
+            <Col xs={5} className="buttons-wrapper no-spacing">
               <Button
-                className="pull-right"
                 bsStyle="gbpl-secondary-tint-2-link"
                 disabled={!this.props.exportUrl}
                 href={this.props.exportUrl}
@@ -102,10 +101,8 @@ class QueryBox extends Component {
               >
                 EXPORT
               </Button>
-            </Col>
-            <Col xs={3}>
               <Button
-                className="pull-right"
+                className="run-query"
                 bsStyle="gbpl-secondary"
                 disabled={this.props.enabled === false}
                 onClick={this.props.handleSubmit}

--- a/frontend/src/components/QueryBox.less
+++ b/frontend/src/components/QueryBox.less
@@ -12,18 +12,6 @@
     border: solid 1px @primary;
     background-color: @query-results-block;
 
-    .meta-wrapper {
-        display: table;
-        height: 100%;
-
-        .meta {
-            display: table-cell;
-            vertical-align: middle;
-
-            font-size: 14px;
-        }
-    }
-
     .codemirror-row {
         flex-grow: 1;
         display: flex;
@@ -36,6 +24,28 @@
         border-top: solid 1px @primary-tint-3;
         padding: @big-spacing;
         margin: 0;
+
+        .meta-wrapper {
+            display: table;
+            height: 100%;
+
+            .meta {
+                display: table-cell;
+                vertical-align: middle;
+
+                font-size: 14px;
+            }
+        }
+
+        .buttons-wrapper {
+            text-align: right;
+        }
+
+        button.run-query {
+            padding-left: 35px;
+            padding-right: 35px;
+            margin-left: @big-spacing;
+        }
     }
 
     .codemirror-col {
@@ -44,10 +54,6 @@
 
     .react-codemirror2 {
         height: 100%;
-    }
-
-    button {
-        width: 100%;
     }
 
     .CodeMirror {

--- a/frontend/src/components/Sidebar.less
+++ b/frontend/src/components/Sidebar.less
@@ -37,7 +37,7 @@
     }
 
     .list {
-        line-height: 1.5;
+        line-height: 1.75;
 
         .glyphicon {
             margin-right: @small-spacing;

--- a/frontend/src/components/TabbedResults.js
+++ b/frontend/src/components/TabbedResults.js
@@ -223,7 +223,7 @@ class TabbedResults extends Component {
             <Tab
               key="history"
               eventKey="history"
-              tabClassName="history"
+              tabClassName="history-tab-title"
               title={
                 <div className="history-tab">
                   <span className="icon-bg">

--- a/frontend/src/components/TabbedResults.less
+++ b/frontend/src/components/TabbedResults.less
@@ -70,7 +70,7 @@
         font-weight: @bold-font-weight;
     }
 
-    li.history {
+    li.history-tab-title {
         float: right;
     }
 

--- a/frontend/src/components/TabbedResults.less
+++ b/frontend/src/components/TabbedResults.less
@@ -72,6 +72,10 @@
 
     li.history-tab-title {
         float: right;
+
+        .tab-title {
+            width: auto;
+        }
     }
 
     .history-tab .icon-bg {


### PR DESCRIPTION
Part of #44.

Makes a few tweaks asked by @ricardobaeta:
- line height for the sidebar list items
- fixed width for the RUN QUERY button
- history tab title width adjusted to the contents.

The commit 54c1a48 was cherry-picked from #144 to avoid merge conflicts.

