### PR TITLE
Set styles for uast-viewer & modals

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -199,7 +199,7 @@ FROM ( SELECT MONTH(committer_when) as month,
     this.setState({
       showModal: true,
       modalTitle: 'Source code',
-      modalContent: <Editor code={code} />
+      modalContent: <Editor code={code} theme="default" />
     });
   }
 

--- a/frontend/src/App.less
+++ b/frontend/src/App.less
@@ -152,7 +152,7 @@ body {
     }
 
     .uast-title-collapsible.collapsed {
-        background-color: rgba(27, 120, 183, 0.04); // @primary, 0.04 opacity
+        background-color: fade(@primary, 4%);
     }
 
     .uast-value.string {
@@ -161,10 +161,10 @@ body {
     }
 
     .uast-content {
-        border-left: 1px solid rgba(118, 174, 211, 0.5); // @primary-tint-2, 0.5 opacity
+        border-left: 1px solid fade(@primary-tint-2, 50%);
     }
 
     .uast-item.hovered {
-        background-color: rgba(78, 204, 123, 0.07); // @secondary, 0.07 opacity
+        background-color: fade(@secondary, 7%)
     }
 }

--- a/frontend/src/App.less
+++ b/frontend/src/App.less
@@ -86,11 +86,17 @@ body {
 // make modal window "fullscreen"
 // margins are hard-coded in bootstrap, so it's hard-coded here too
 .modal-body {
-    height: ~'calc(100vh - 80px)';
-    overflow-y: auto;
+    height: ~'calc(100vh - 150px)';
 
+    .uast-editor,
+    .react-codemirror2,
     .CodeMirror {
         height: 100%;
+    }
+
+    .uast-viewer {
+        height: 100%;
+        overflow-y: auto;
     }
 }
 
@@ -100,7 +106,65 @@ body {
     }
 }
 
-.uast-editor,
-.react-codemirror2 {
+.uast-editor .CodeMirror {
+    font-family: @monospace-font;
+    font-size: 16px;
+    line-height: 1.38;
+
+    .CodeMirror-gutters {
+        background-color: @primary-tint-4;
+        border-right: 0;
+    }
+
+    .CodeMirror-linenumber {
+        opacity: 0.6;
+        color: @primary-tint-2;
+    }
+}
+
+@uast-black: #0f2434;
+
+.uast-viewer {
     height: 100%;
+    overflow-y: auto;
+
+    font-family: @regular-font;
+    font-size: 16px;
+    line-height: 22px;
+
+    .uast-title-collapsible::before,
+    .uast-title-collapsible.collapsed::before {
+        color: @secondary-tint-2;
+    }
+
+    .uast-label,
+    .uast-property-name::after {
+        color: @primary;
+        font-family: @regular-font;
+    }
+
+    .uast-property-name {
+        color: @uast-black;
+    }
+
+    .uast-title-collapsible:hover > span {
+        border-bottom: 1px dashed @uast-black;
+    }
+
+    .uast-title-collapsible.collapsed {
+        background-color: rgba(27, 120, 183, 0.04); // @primary, 0.04 opacity
+    }
+
+    .uast-value.string {
+        color: @secondary-tint-2;
+        font-weight: bold;
+    }
+
+    .uast-content {
+        border-left: 1px solid rgba(118, 174, 211, 0.5); // @primary-tint-2, 0.5 opacity
+    }
+
+    .uast-item.hovered {
+        background-color: rgba(78, 204, 123, 0.07); // @secondary, 0.07 opacity
+    }
 }

--- a/frontend/src/variables.less
+++ b/frontend/src/variables.less
@@ -159,3 +159,37 @@
     height: @btn-title-size;
     width: @btn-title-size;
 }
+
+//== Modals
+
+//** Padding applied to the modal body
+@modal-inner-padding: 15px 0px 30px 0px;
+
+//** Padding applied to the modal title
+@modal-title-padding: 0px 0px 15px 0px;
+//** Modal title line-height
+@modal-title-line-height: normal;
+
+//** Modal backdrop background color
+@modal-backdrop-bg:           @primary;
+//** Modal backdrop opacity
+@modal-backdrop-opacity:      0.7;
+
+.modal-content {
+    box-shadow: unset;
+    border-radius: unset;
+    border: solid 1px @primary;
+
+    padding: 30px 30px 15px 30px;
+
+    .modal-header {
+        border-bottom: solid 1px @primary-tint-3;
+
+        .modal-title {
+            color: @dark-text;
+            font-size: 20px;
+            font-weight: normal;
+            letter-spacing: 0.8px;
+        }
+    }
+}


### PR DESCRIPTION
Part of #44.

Sets the overall modal styles, and the fonts and colors for the code and uast viewers.
The only difference with the design spec is the code viewer font, set to monospace instead of 'source sans'.

![a](https://user-images.githubusercontent.com/1469173/41660552-a854ca24-749c-11e8-9709-43251b2d38aa.png)
![b](https://user-images.githubusercontent.com/1469173/41660555-a99d108a-749c-11e8-9ca8-ffa213013120.png)
