### PR TITLE
Show UAST from code

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,6 +47,12 @@
     },
     "/schema": {
       "target": "http://localhost:8080"
+    },
+    "/detect-lang": {
+      "target": "http://localhost:8080"
+    },
+    "/parse": {
+      "target": "http://localhost:8080"
     }
   }
 }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -3,12 +3,13 @@ import { Helmet } from 'react-helmet';
 import { Grid, Row, Modal } from 'react-bootstrap';
 import nanoid from 'nanoid';
 import SplitPane from 'react-split-pane';
-import UASTViewer, { Editor, transformer } from 'uast-viewer';
+import UASTViewer, { transformer } from 'uast-viewer';
 import 'uast-viewer/dist/default-theme.css';
 import initButtonStyles from './utils/bootstrap';
 import Sidebar from './components/Sidebar';
 import QueryBox from './components/QueryBox';
 import TabbedResults from './components/TabbedResults';
+import CodeViewer from './components/CodeViewer';
 import api from './api';
 import { STATUS_LOADING, STATUS_ERROR, STATUS_SUCCESS } from './state/query';
 import './App.less';
@@ -230,7 +231,7 @@ FROM ( SELECT MONTH(committer_when) as month,
     this.setState({
       showModal: true,
       modalTitle: 'Source code',
-      modalContent: <Editor code={code} theme="default" />
+      modalContent: <CodeViewer code={code} />
     });
   }
 

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -116,8 +116,35 @@ function schema() {
   return apiCall(`/schema`).then(res => res.data);
 }
 
+function detectLang(content, filename) {
+  return apiCall('/detect-lang', {
+    method: 'POST',
+    body: {
+      content,
+      filename
+    }
+  }).then(res => res.data);
+}
+
+function parseCode(language, content) {
+  return apiCall('/parse', {
+    method: 'POST',
+    body: {
+      language,
+      content
+    }
+  }).then(res => {
+    if (res.data.status !== 0) {
+      throw normalizeErrors(res.data.errors);
+    }
+    return res.data.uast;
+  });
+}
+
 export default {
   query,
   schema,
-  queryExport
+  queryExport,
+  detectLang,
+  parseCode
 };

--- a/frontend/src/components/CodeViewer.js
+++ b/frontend/src/components/CodeViewer.js
@@ -1,0 +1,183 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import SplitPane from 'react-split-pane';
+import UASTViewer, { Editor, withUASTEditor } from 'uast-viewer';
+import api from '../api';
+import './CodeViewer.less';
+
+const avaliableLangs = ['JavaScript', 'Go'];
+
+function EditorPane({
+  language,
+  showUast,
+  handleLangChange,
+  handleShowUastChange,
+  editorProps
+}) {
+  return (
+    <div>
+      {' '}
+      Language:{' '}
+      <select value={language} onChange={handleLangChange}>
+        <option>Select language</option>
+        {avaliableLangs.map(lang => (
+          <option key={lang} value={lang.toLowerCase()}>
+            {lang}
+          </option>
+        ))}
+      </select>
+      <label>
+        <input
+          type="checkbox"
+          checked={showUast}
+          onChange={handleShowUastChange}
+          disabled={!language}
+        />UAST
+      </label>
+      <Editor {...editorProps} theme="default" />
+    </div>
+  );
+}
+
+EditorPane.propTypes = {
+  language: PropTypes.string,
+  showUast: PropTypes.bool,
+  handleLangChange: PropTypes.func.isRequired,
+  handleShowUastChange: PropTypes.func.isRequired,
+  editorProps: PropTypes.object
+};
+
+function EditorUASTSpitPane({
+  editorProps,
+  uastViewerProps,
+  showUast,
+  handleLangChange,
+  handleShowUastChange
+}) {
+  return (
+    <SplitPane split="vertical" defaultSize={250} minSize={175}>
+      <EditorPane
+        language={editorProps.languageMode}
+        showUast={showUast}
+        handleLangChange={handleLangChange}
+        handleShowUastChange={handleShowUastChange}
+        editorProps={editorProps}
+      />
+      <UASTViewer {...uastViewerProps} />
+    </SplitPane>
+  );
+}
+
+EditorUASTSpitPane.propTypes = {
+  editorProps: PropTypes.object,
+  uastViewerProps: PropTypes.object,
+  showUast: PropTypes.bool,
+  handleLangChange: PropTypes.func.isRequired,
+  handleShowUastChange: PropTypes.func.isRequired
+};
+
+const EditorWithUAST = withUASTEditor(EditorUASTSpitPane);
+
+class CodeViewer extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      loading: true,
+      language: null,
+      showUast: false,
+      uast: null,
+      error: null
+    };
+
+    this.handleLangChange = this.handleLangChange.bind(this);
+    this.handleShowUastChange = this.handleShowUastChange.bind(this);
+    this.removeError = this.removeError.bind(this);
+  }
+
+  componentDidMount() {
+    api.detectLang(this.props.code).then(res => {
+      this.setState({ loading: false, language: res.language });
+    });
+  }
+
+  handleLangChange(e) {
+    this.setState({ language: e.target.value }, () => {
+      if (this.state.language && this.state.showUast) {
+        this.parseCode();
+      }
+    });
+  }
+
+  handleShowUastChange() {
+    const showUast = !this.state.showUast;
+    if (showUast) {
+      this.parseCode();
+    }
+    this.setState({ showUast });
+  }
+
+  parseCode() {
+    this.setState({ error: null });
+
+    api
+      .parseCode(this.state.language, this.props.code)
+      .then(res => {
+        this.setState({ uast: res });
+      })
+      .catch(error => {
+        this.setState({ error });
+      });
+  }
+
+  removeError() {
+    this.setState({ error: null });
+  }
+
+  render() {
+    const { loading, language, showUast, uast, error } = this.state;
+
+    if (loading) {
+      return 'loading';
+    }
+
+    if (showUast) {
+      return (
+        <div className="code-viewer">
+          <EditorWithUAST
+            code={this.props.code}
+            languageMode={language}
+            showUast={showUast}
+            handleLangChange={this.handleLangChange}
+            handleShowUastChange={this.handleShowUastChange}
+            uast={uast}
+          />
+          {error ? (
+            <div className="error">
+              <button onClick={this.removeError} className="close">
+                close
+              </button>
+              {error}
+            </div>
+          ) : null}
+        </div>
+      );
+    }
+
+    return (
+      <EditorPane
+        language={language}
+        showUast={showUast}
+        handleLangChange={this.handleLangChange}
+        handleShowUastChange={this.handleShowUastChange}
+        editorProps={{ code: this.props.code, languageMode: language }}
+      />
+    );
+  }
+}
+
+CodeViewer.propTypes = {
+  code: PropTypes.string.isRequired
+};
+
+export default CodeViewer;

--- a/frontend/src/components/CodeViewer.js
+++ b/frontend/src/components/CodeViewer.js
@@ -5,7 +5,16 @@ import UASTViewer, { Editor, withUASTEditor } from 'uast-viewer';
 import api from '../api';
 import './CodeViewer.less';
 
-const avaliableLangs = ['JavaScript', 'Go'];
+const avaliableLangs = [
+  'Java',
+  'Go',
+  'Python',
+  'JavaScript',
+  'Php',
+  'Ruby',
+  'Typescript',
+  'Bash'
+];
 
 function EditorPane({
   language,

--- a/frontend/src/components/CodeViewer.js
+++ b/frontend/src/components/CodeViewer.js
@@ -27,7 +27,7 @@ function EditorPane({
     <div className="editor-pane">
       Language:{' '}
       <select value={language} onChange={handleLangChange}>
-        <option>Select language</option>
+        <option value="">Select language</option>
         {avaliableLangs.map(lang => (
           <option key={lang} value={lang.toLowerCase()}>
             {lang}
@@ -104,14 +104,27 @@ class CodeViewer extends Component {
   }
 
   componentDidMount() {
-    api.detectLang(this.props.code).then(res => {
-      this.setState({ loading: false, language: res.language });
-    });
+    api
+      .detectLang(this.props.code)
+      .then(res => {
+        this.setState({ language: res.language });
+      })
+      .catch(err => {
+        // we don't have UI for this error and actually it's not very important
+        // user can select language manualy
+        console.error(`can't detect language: ${err}`);
+      })
+      .then(() => this.setState({ loading: false }));
   }
 
   handleLangChange(e) {
     this.setState({ language: e.target.value }, () => {
-      if (this.state.language && this.state.showUast) {
+      if (!this.state.language) {
+        this.setState({ showUast: false });
+        return;
+      }
+
+      if (this.state.showUast) {
         this.parseCode();
       }
     });
@@ -126,7 +139,7 @@ class CodeViewer extends Component {
   }
 
   parseCode() {
-    this.setState({ error: null });
+    this.setState({ error: null, uast: null });
 
     api
       .parseCode(this.state.language, this.props.code)

--- a/frontend/src/components/CodeViewer.js
+++ b/frontend/src/components/CodeViewer.js
@@ -24,8 +24,7 @@ function EditorPane({
   editorProps
 }) {
   return (
-    <div>
-      {' '}
+    <div className="editor-pane">
       Language:{' '}
       <select value={language} onChange={handleLangChange}>
         <option>Select language</option>

--- a/frontend/src/components/CodeViewer.less
+++ b/frontend/src/components/CodeViewer.less
@@ -1,0 +1,19 @@
+.code-viewer {
+    position: relative;
+    height: 100%;
+    overflow: hidden;
+
+    .error {
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        height: 100px;
+
+        padding: 10px;
+        background: rgba(0, 0, 0, 0.5);
+        color: #fff;
+
+        z-index: 10;
+    }
+}

--- a/frontend/src/components/CodeViewer.less
+++ b/frontend/src/components/CodeViewer.less
@@ -17,3 +17,7 @@
         z-index: 10;
     }
 }
+
+.editor-pane {
+    height: 100%;
+}

--- a/server/handler/export.go
+++ b/server/handler/export.go
@@ -80,7 +80,7 @@ func Export(db service.SQLDB) http.HandlerFunc {
 						// DatabaseTypeName JSON is used for arrays of uast nodes and
 						// arrays of strings, but we don't know the exact type.
 						// We try with arry of uast nodes first and any JSON later
-						nodes, err := unmarshallUAST(val)
+						nodes, err := service.UnmarshallUAST(val)
 						if err == nil {
 							b, err := json.Marshal(nodes)
 							if err != nil {

--- a/server/handler/query.go
+++ b/server/handler/query.go
@@ -113,7 +113,7 @@ func Query(db service.SQLDB) RequestProcessFunc {
 					// DatabaseTypeName JSON is used for arrays of uast nodes and
 					// arrays of strings, but we don't know the exact type.
 					// We try with arry of uast nodes first and any JSON later
-					nodes, err := unmarshallUAST(val)
+					nodes, err := service.UnmarshallUAST(val)
 					if err == nil {
 						colData[columnNames[i]] = nodes
 					} else {

--- a/server/serializer/serializers.go
+++ b/server/serializer/serializers.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"strings"
 
-	"gopkg.in/bblfsh/sdk.v1/protocol"
+	"github.com/src-d/gitbase-playground/server/service"
 	enry "gopkg.in/src-d/enry.v1"
 )
 
@@ -120,8 +120,8 @@ func NewSchemaResponse(tables map[string][]Column) *Response {
 }
 
 // NewParseResponse returns a Response with UAST
-func NewParseResponse(resp *protocol.ParseResponse) *Response {
-	return newResponse(resp.UAST, nil)
+func NewParseResponse(resp *service.ParseResponse) *Response {
+	return newResponse(resp, nil)
 }
 
 // NewDetectLangResponse returns a Response with detected language

--- a/server/service/uast.go
+++ b/server/service/uast.go
@@ -1,0 +1,75 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"gopkg.in/bblfsh/sdk.v1/protocol"
+	"gopkg.in/bblfsh/sdk.v1/uast"
+)
+
+// need to move to service to avoid circular imports
+
+// UnmarshallUAST tries to cast data as [][]byte and unmarshall uast nodes
+func UnmarshallUAST(data interface{}) ([]*Node, error) {
+	var protobufs [][]byte
+	if err := json.Unmarshal(*data.(*[]byte), &protobufs); err != nil {
+		return nil, err
+	}
+
+	nodes := make([]*Node, len(protobufs))
+
+	for i, v := range protobufs {
+		n := uast.NewNode()
+		if err := n.Unmarshal(v); err != nil {
+			return nil, err
+		}
+		nodes[i] = (*Node)(n)
+	}
+
+	return nodes, nil
+}
+
+// ParseResponse amends default MarshalJSON to be compatible with frontend
+type ParseResponse protocol.ParseResponse
+
+// MarshalJSON returns the JSON representation of the protocol.ParseResponse
+func (r *ParseResponse) MarshalJSON() ([]byte, error) {
+	fmt.Println("MarshalJSON")
+	resp := struct {
+		*protocol.ParseResponse
+		UAST *Node `json:"uast"`
+	}{
+		(*protocol.ParseResponse)(r),
+		(*Node)(r.UAST),
+	}
+
+	return json.Marshal(resp)
+}
+
+type Node uast.Node
+
+// MarshalJSON returns the JSON representation of the Node
+func (n *Node) MarshalJSON() ([]byte, error) {
+	var nodes = make([]*Node, len(n.Children))
+	for i, n := range n.Children {
+		nodes[i] = (*Node)(n)
+	}
+
+	var roles = make([]string, len(n.Roles))
+	for i, r := range n.Roles {
+		roles[i] = r.String()
+	}
+
+	node := struct {
+		*uast.Node
+		Roles    []string
+		Children []*Node
+	}{
+		(*uast.Node)(n),
+		roles,
+		nodes,
+	}
+
+	return json.Marshal(node)
+}


### PR DESCRIPTION
Part of #48 

<img width="948" alt="screen shot 2018-06-20 at 16 25 13" src="https://user-images.githubusercontent.com/406916/41664744-b373209a-74a6-11e8-9b21-86557752c671.png">
<img width="933" alt="screen shot 2018-06-20 at 16 25 24" src="https://user-images.githubusercontent.com/406916/41664745-b445e1f6-74a6-11e8-9961-c27c260ba3f4.png">
<img width="928" alt="screen shot 2018-06-20 at 16 25 43" src="https://user-images.githubusercontent.com/406916/41664746-b4c9863c-74a6-11e8-9b4a-ef360329d343.png">

Because this issue isn't about design there are few differences that will need to fix in sequential prs:
- show uast button is located in left pane not in the title of modal (it would complicate code)
- there is no top bar on UAST (with locations, server, query) yet. The PR is big enough already. Better implement separately.
- it doesn't return underlying error from bblfsh
- list of languages is hard-coded 
- there are no workarounds for java/bash/??? yet (languageMode != language for them)
- it works freaking slow