### PR TITLE
Improve split panels min & max sizes

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -354,7 +354,8 @@ FROM ( SELECT MONTH(committer_when) as month,
               className="main-split"
               split="horizontal"
               defaultSize={250}
-              minSize={175}
+              minSize={1}
+              maxSize={-15}
             >
               <QueryBox
                 sql={this.state.sql}

--- a/frontend/src/App.less
+++ b/frontend/src/App.less
@@ -10,6 +10,7 @@ body,
 
 body {
     max-height: 100%;
+    min-height: 500px;
     background-color: @primary-tint-4;
     font-family: @regular-font;
     font-size: 13px;

--- a/frontend/src/components/QueryBox.less
+++ b/frontend/src/components/QueryBox.less
@@ -6,6 +6,7 @@
 
 .query-box {
     height: 100%;
+    overflow: hidden;
     display: flex;
     flex-direction: column;
 

--- a/frontend/src/components/Sidebar.js
+++ b/frontend/src/components/Sidebar.js
@@ -31,7 +31,12 @@ class Sidebar extends Component {
           <Glyphicon onClick={this.handleToggle} glyph={togglerIcon} />
         </div>
         <div className="main">
-          <SplitPane split="horizontal" defaultSize={200} minSize={100}>
+          <SplitPane
+            split="horizontal"
+            defaultSize={300}
+            minSize={0}
+            maxSize={-15}
+          >
             <Schema schema={schema} onTableClick={onTableClick} />
             <SampleQueries
               onExampleClick={onExampleClick}

--- a/frontend/src/components/Sidebar.less
+++ b/frontend/src/components/Sidebar.less
@@ -46,6 +46,7 @@
 
     .main {
         flex: 1 1;
+        overflow: hidden;
         margin-bottom: @small-spacing;
     }
 


### PR DESCRIPTION
Fixes #121.

Fixes the overflow problems. New `minSize` and `maxSize` to completely hide the top or bottom panels.

![a](https://user-images.githubusercontent.com/1469173/41725297-bbad3204-756f-11e8-904d-816477b8680f.png)
