### PR TITLE
Show error messages in main query box

### DIFF
--- a/frontend/src/components/QueryBox.js
+++ b/frontend/src/components/QueryBox.js
@@ -13,6 +13,36 @@ import 'codemirror/addon/hint/sql-hint';
 
 import './QueryBox.less';
 import SuccessIcon from '../icons/success-query.svg';
+import ErrorIcon from '../icons/error-query.svg';
+
+function ResultInfo({ result }) {
+  if (!result) {
+    return null;
+  }
+
+  if (result.response && result.response.meta) {
+    return (
+      <span className="meta meta-success">
+        <SuccessIcon className="big-icon" />Showing rows (query took{' '}
+        {result.response.meta.elapsedTime / 1000} seconds)
+      </span>
+    );
+  }
+
+  if (result.errorMsg) {
+    return (
+      <span className="meta meta-error">
+        <ErrorIcon className="big-icon" />Query Failed - {result.errorMsg}
+      </span>
+    );
+  }
+
+  return null;
+}
+
+ResultInfo.propTypes = {
+  result: PropTypes.object
+};
 
 class QueryBox extends Component {
   constructor(props) {
@@ -50,7 +80,7 @@ class QueryBox extends Component {
   }
 
   render() {
-    const { resultMeta } = this.props;
+    const { result } = this.props;
     const { codeMirrorTables } = this.state;
 
     const options = {
@@ -69,16 +99,6 @@ class QueryBox extends Component {
       }
     };
 
-    let meta = '';
-    if (resultMeta) {
-      meta = (
-        <span className="meta">
-          <SuccessIcon className="big-icon" />Showing rows (query took{' '}
-          {resultMeta.elapsedTime / 1000} seconds)
-        </span>
-      );
-    }
-
     return (
       <div className="query-box-padding full-height full-width">
         <div className="query-box full-height full-width">
@@ -95,7 +115,7 @@ class QueryBox extends Component {
           </Row>
           <Row className="button-row">
             <Col xs={7} className="meta-wrapper no-spacing">
-              {meta}
+              <ResultInfo result={result} />
             </Col>
             <Col xs={5} className="buttons-wrapper no-spacing">
               <Button
@@ -135,7 +155,7 @@ QueryBox.propTypes = {
       ).isRequired
     })
   ),
-  resultMeta: PropTypes.object,
+  result: PropTypes.object,
   enabled: PropTypes.bool,
   handleTextChange: PropTypes.func.isRequired,
   handleSubmit: PropTypes.func.isRequired,

--- a/frontend/src/components/QueryBox.less
+++ b/frontend/src/components/QueryBox.less
@@ -34,15 +34,26 @@
             .meta {
                 .big-icon {
                     margin-right: 15px;
-                    path {
-                        fill: @success;
-                    }
                 }
 
                 display: table-cell;
                 vertical-align: middle;
 
                 font-size: 14px;
+
+                &.meta-success {
+                    svg path {
+                        fill: @success;
+                    }
+                }
+
+                &.meta-error {
+                    color: @error-text;
+
+                    svg path {
+                        fill: @error-text;
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Part of #44.

Implements the design spec for error messages.

Now when an error happens:
- The error message is displayed in the main query box
- The loading tab is deleted

Other change: the last success or error message is cleared when the 'run query' button is clicked.

![a](https://user-images.githubusercontent.com/1469173/41767479-fff4b60e-7609-11e8-8057-de7de1e27b0c.png)
