### PR TITLE
Style for the modal contents

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -12,6 +12,7 @@ import TabbedResults from './components/TabbedResults';
 import api from './api';
 import { STATUS_LOADING, STATUS_ERROR, STATUS_SUCCESS } from './state/query';
 import './App.less';
+import CloseIcon from './icons/close-query-tab.svg';
 
 const INACTIVE_TIMEOUT = 3600000;
 
@@ -236,7 +237,15 @@ FROM ( SELECT MONTH(committer_when) as month,
   showUAST(uast) {
     this.setState({
       showModal: true,
-      modalTitle: 'UAST',
+      modalTitle: (
+        <div>
+          UAST
+          <CloseIcon
+            className="btn-modal-close"
+            onClick={this.handleModalClose}
+          />
+        </div>
+      ),
       modalContent:
         // currently gitbase returns only 1 item, UAST of the file
         // but just in case if there is more or less we show it without viewer
@@ -393,7 +402,7 @@ FROM ( SELECT MONTH(committer_when) as month,
           onHide={this.handleModalClose}
           bsSize="large"
         >
-          <Modal.Header closeButton>
+          <Modal.Header>
             <Modal.Title>{this.state.modalTitle}</Modal.Title>
           </Modal.Header>
           <Modal.Body>{this.state.modalContent}</Modal.Body>

--- a/frontend/src/App.less
+++ b/frontend/src/App.less
@@ -107,12 +107,6 @@ body {
 .modal-body {
     height: ~'calc(100vh - 150px)';
 
-    .uast-editor,
-    .react-codemirror2,
-    .CodeMirror {
-        height: 100%;
-    }
-
     .uast-viewer {
         height: 100%;
         overflow-y: auto;

--- a/frontend/src/App.less
+++ b/frontend/src/App.less
@@ -59,7 +59,7 @@ body {
         overflow: auto;
     }
 
-    .Resizer {
+    .Resizer.horizontal {
         border-top: solid 1px @primary-tint-2;
         border-bottom: solid 1px @primary-tint-2;
         background-color: @query-results-block;
@@ -71,6 +71,28 @@ body {
             content: '● ● ●';
             text-align: center;
             line-height: 13px;
+            font-size: 8px;
+        }
+    }
+
+    .Resizer.vertical {
+        border-left: solid 1px @primary-tint-2;
+        border-right: solid 1px @primary-tint-2;
+        background-color: @primary-tint-3;
+
+        cursor: col-resize;
+
+        display: flex;
+        justify-content: center;
+        flex-direction: column;
+        width: 13px;
+
+        &:before {
+            display: block;
+            content: "●\A●\A●";
+            white-space: pre;
+            text-align: center;
+            line-height: 1em;
             font-size: 8px;
         }
     }

--- a/frontend/src/components/CodeViewer.js
+++ b/frontend/src/components/CodeViewer.js
@@ -10,6 +10,7 @@ import UASTViewer, {
 import Switch from 'react-switch';
 import api from '../api';
 import './CodeViewer.less';
+import CloseIcon from '../icons/close-query-tab.svg';
 
 function EditorPane({ languages, language, handleLangChange, editorProps }) {
   return (
@@ -341,7 +342,7 @@ class CodeViewer extends Component {
 
     return (
       <Modal show={showModal} onHide={onHide} bsSize="large">
-        <Modal.Header closeButton>
+        <Modal.Header>
           <Modal.Title>
             CODE
             <Switch
@@ -357,6 +358,7 @@ class CodeViewer extends Component {
               className={`code-toggler ${showUast ? 'checked' : 'unchecked'}`}
               aria-label="Toggle UAST view"
             />
+            <CloseIcon className="btn-modal-close" onClick={onHide} />
           </Modal.Title>
         </Modal.Header>
         <Modal.Body>

--- a/frontend/src/components/CodeViewer.js
+++ b/frontend/src/components/CodeViewer.js
@@ -179,7 +179,7 @@ function EditorUASTSpitPane({
   handleSearch
 }) {
   return (
-    <SplitPane split="vertical" defaultSize={250} minSize={175}>
+    <SplitPane split="vertical" defaultSize={500} minSize={1} maxSize={-15}>
       <EditorPane
         languages={languages}
         language={editorProps.languageMode}

--- a/frontend/src/components/CodeViewer.js
+++ b/frontend/src/components/CodeViewer.js
@@ -383,10 +383,14 @@ class CodeViewer extends Component {
               />
               {error ? (
                 <div className="error">
-                  <button onClick={this.removeError} className="close">
-                    close
-                  </button>
-                  {error}
+                  <div className="error-header">
+                    <span>ERROR</span>
+                    <CloseIcon
+                      className="btn-error-close"
+                      onClick={this.removeError}
+                    />
+                  </div>
+                  <div className="error-msg">{error}</div>
                 </div>
               ) : null}
             </div>

--- a/frontend/src/components/CodeViewer.js
+++ b/frontend/src/components/CodeViewer.js
@@ -15,15 +15,17 @@ import CloseIcon from '../icons/close-query-tab.svg';
 function EditorPane({ languages, language, handleLangChange, editorProps }) {
   return (
     <div className="editor-pane">
-      Language:{' '}
-      <select value={language} onChange={handleLangChange}>
-        <option value="">Select language</option>
-        {languages.map(lang => (
-          <option key={lang.id} value={lang.id}>
-            {lang.name}
-          </option>
-        ))}
-      </select>
+      <div className="language-selection">
+        <span className="lang-label">LANGUAGE</span>
+        <select value={language} onChange={handleLangChange}>
+          <option value="">Select language</option>
+          {languages.map(lang => (
+            <option key={lang.id} value={lang.id}>
+              {lang.name}
+            </option>
+          ))}
+        </select>
+      </div>
       <Editor
         {...editorProps}
         languageMode={languageToMode(language)}

--- a/frontend/src/components/CodeViewer.less
+++ b/frontend/src/components/CodeViewer.less
@@ -50,6 +50,56 @@
 
 .editor-pane {
     height: 100%;
+    display: flex;
+    flex-direction: column;
+
+    .language-selection {
+        flex: 0 0 auto;
+
+        padding: 5px 0px 5px 60px;
+        border-bottom: solid 1px @primary-tint-3;
+        margin-bottom: 15px;
+
+        overflow-x: hidden;
+
+        .lang-label {
+            color: fade(@primary-tint-2, 63%);
+            font-size: 16px;
+
+            margin-right: 20px;
+        }
+
+        select {
+            font-family: @monospace-font;
+            font-size: 12px;
+            font-weight: bold;
+            color: @primary;
+
+            width: 256px;
+            min-width: 30px;
+            padding: 8px 0px 8px 15px;
+        }
+    }
+
+    .uast-editor {
+        height: 100%;
+        flex: 1 1 auto;
+
+        display: flex;
+        flex-direction: column;
+
+        .react-codemirror2 {
+            height: 100%;
+            flex: 1 1 auto;
+
+            display: flex;
+            flex-direction: column;
+
+            .CodeMirror {
+                flex: 1 1 auto;
+            }
+        }
+    }
 }
 
 .code-toggler {

--- a/frontend/src/components/CodeViewer.less
+++ b/frontend/src/components/CodeViewer.less
@@ -10,13 +10,41 @@
         bottom: 0;
         left: 0;
         right: 0;
-        height: 100px;
-
-        padding: 10px;
-        background: rgba(0, 0, 0, 0.5);
-        color: #fff;
-
         z-index: 10;
+
+        min-height: 20%;
+        max-height: 80%;
+        padding: 20px 35px;
+        background-color: fade(@primary-tint-1, 88%);
+
+        display: flex;
+        flex-direction: column;
+
+        .error-header {
+            margin-bottom: 10px;
+
+            span {
+                font-size: 18px;
+                font-weight: @bold-font-weight;
+                line-height: 1.22;
+                color: @primary-tint-2;
+            }
+
+            .btn-error-close {
+                .btn-title-common;
+                .icon-btn-variant(@primary-tint-2);
+
+                float: right;
+            }
+        }
+
+        .error-msg {
+            color: @primary-tint-3;
+            line-height: 1.63;
+            font-size: 16px;
+            white-space: pre;
+            overflow: auto;
+        }
     }
 }
 

--- a/frontend/src/components/Sidebar.less
+++ b/frontend/src/components/Sidebar.less
@@ -61,7 +61,7 @@
     }
 
     .SplitPane {
-        .Resizer {
+        .Resizer.horizontal {
             background-color: @primary-tint-3;
         }
 

--- a/frontend/src/components/TabbedResults.less
+++ b/frontend/src/components/TabbedResults.less
@@ -82,8 +82,6 @@
         padding-right: 50px;
     }
 
-    @btn-title-size: 22px;
-
     .nav-tabs {
         li.history-tab-title {
             float: right;
@@ -103,19 +101,6 @@
             display: inline-block;
             font-family: @monospace-font;
             font-weight: @bold-font-weight;
-        }
-
-        .btn-title-common {
-            height: @btn-title-size;
-            width: @btn-title-size;
-            display: inline-block;
-            vertical-align: middle;
-        }
-
-        .btn-title {
-            .btn-title-common;
-            margin-left: 1ex;
-            .icon-btn-variant(@primary-tint-2);
         }
 
         > li.active {

--- a/frontend/src/variables.less
+++ b/frontend/src/variables.less
@@ -216,6 +216,10 @@
 //** Modal backdrop opacity
 @modal-backdrop-opacity:      0.7;
 
+.modal-dialog {
+    width: 90%;
+}
+
 .modal-content {
     box-shadow: unset;
     border-radius: unset;

--- a/frontend/src/variables.less
+++ b/frontend/src/variables.less
@@ -73,6 +73,21 @@
     }
 }
 
+@btn-title-size: 22px;
+
+.btn-title-common {
+    height: @btn-title-size;
+    width: @btn-title-size;
+    display: inline-block;
+    vertical-align: middle;
+}
+
+.btn-title {
+    .btn-title-common;
+    margin-left: 1ex;
+    .icon-btn-variant(@primary-tint-2);
+}
+
 //=== Buttons
 @btn-font-weight: @bold-font-weight;
 
@@ -237,4 +252,11 @@
             letter-spacing: 0.8px;
         }
     }
+}
+
+.btn-modal-close {
+    .btn-title-common;
+    .icon-btn-variant(@primary);
+
+    float: right;
 }

--- a/frontend/src/variables.less
+++ b/frontend/src/variables.less
@@ -2,6 +2,7 @@
 
 //=== Colors
 @primary:           #1b78b7;
+@primary-tint-1:    #082436;
 @primary-tint-2:    #76aed3;
 @primary-tint-3:    #e8f1f7;
 @primary-tint-4:    #f5f9fb;


### PR DESCRIPTION
Part of #48.

There is a small difference with the design spec: the blue background of the code line gutter does not carry all the way to the top.
The reason is that the width is not fixed, it depends on the number of lines, it has different widths for 1 or 3 digit line numbers. There must be a convoluted way to make it work, but I think it's not worth it, at least for now.

![a](https://user-images.githubusercontent.com/1469173/41969939-5a5e9d50-7a09-11e8-9745-fd70bc5d8b37.png)

![b](https://user-images.githubusercontent.com/1469173/41969943-5ce6a3ba-7a09-11e8-8c32-2b6e104cf2f8.png)

![c](https://user-images.githubusercontent.com/1469173/41969947-5ee8e54c-7a09-11e8-80f4-84422f18c3ce.png)
