### PR TITLE
Highlighting fixes

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,7 @@
     "react-split-pane": "^0.1.77",
     "react-switch": "^3.0.4",
     "react-table": "^6.8.2",
-    "uast-viewer": "^0.0.4"
+    "uast-viewer": "^0.0.5"
   },
   "scripts": {
     "start": "react-app-rewired start",

--- a/frontend/src/components/CodeViewer.js
+++ b/frontend/src/components/CodeViewer.js
@@ -2,7 +2,11 @@ import React, { Component } from 'react';
 import { Modal, Button } from 'react-bootstrap';
 import PropTypes from 'prop-types';
 import SplitPane from 'react-split-pane';
-import UASTViewer, { Editor, withUASTEditor } from 'uast-viewer';
+import UASTViewer, {
+  Editor,
+  withUASTEditor,
+  languageToMode
+} from 'uast-viewer';
 import Switch from 'react-switch';
 import api from '../api';
 import './CodeViewer.less';
@@ -19,7 +23,11 @@ function EditorPane({ languages, language, handleLangChange, editorProps }) {
           </option>
         ))}
       </select>
-      <Editor {...editorProps} theme="default" />
+      <Editor
+        {...editorProps}
+        languageMode={languageToMode(language)}
+        theme="default"
+      />
     </div>
   );
 }
@@ -385,7 +393,7 @@ class CodeViewer extends Component {
               languages={languages}
               language={language}
               handleLangChange={this.handleLangChange}
-              editorProps={{ code, languageMode: language }}
+              editorProps={{ code }}
             />
           )}
         </Modal.Body>

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7092,9 +7092,9 @@ ua-parser-js@^0.7.9:
   version "0.7.18"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.18.tgz#a7bfd92f56edfb117083b69e31d2aa8882d4b1ed"
 
-uast-viewer@^0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/uast-viewer/-/uast-viewer-0.0.4.tgz#d3575aa8a74f8d814b65ad546ebfd1f03685ee5d"
+uast-viewer@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/uast-viewer/-/uast-viewer-0.0.5.tgz#e7ca267840cf8a8b8fb26e83ecb60249957aa2a1"
 
 uglify-js@3.3.x, uglify-js@^3.0.13:
   version "3.3.23"


### PR DESCRIPTION
Fix: #130 

Example of java highlighting:

<img width="886" alt="screen shot 2018-06-27 at 15 20 32" src="https://user-images.githubusercontent.com/406916/41976669-f49a30aa-7a1d-11e8-99dc-3823ed8240d6.png">

Because of the lib update bug with a cursor in editor on node click is also fixed.