### PR TITLE
Fix missing scroll in query box

### DIFF
--- a/frontend/src/components/QueryBox.less
+++ b/frontend/src/components/QueryBox.less
@@ -69,7 +69,7 @@
     }
 
     .codemirror-col {
-        flex: 1;
+        flex: 1 1 auto;
     }
 
     .react-codemirror2 {
@@ -84,7 +84,7 @@
 
         .CodeMirror-gutters {
             border-right: 0;
-            background-color: unset;
+            background-color: @query-results-block;
         }
     }
 


### PR DESCRIPTION
#147

Adds the missing scroll in the main query box.

There is, however, a problem I'm not able to fix. The horizontal scroll on firefox covers half of the last line. This does not happen if CodeMirror `lineNumbers` is enabled. It might be related to https://github.com/codemirror/CodeMirror/issues/3821.

Chrome on top, firefox below it:

![a](https://user-images.githubusercontent.com/1469173/42039046-bddcccb0-7aec-11e8-9de1-5148d05f911b.png)