### PR TITLE
Shrink tab titles to fit in one line

### DIFF
--- a/frontend/src/components/TabbedResults.js
+++ b/frontend/src/components/TabbedResults.js
@@ -1,5 +1,13 @@
 import React, { Component, Fragment } from 'react';
-import { Row, Col, Alert, Tab, Button } from 'react-bootstrap';
+import {
+  Row,
+  Col,
+  Alert,
+  Tab,
+  Button,
+  OverlayTrigger,
+  Popover
+} from 'react-bootstrap';
 import PropTypes from 'prop-types';
 import DivTabs from './DivTabs';
 import ResultsTable from './ResultsTable';
@@ -57,7 +65,7 @@ class TabTitle extends Component {
 
     if (inEdit) {
       return (
-        <div ref={this.ref}>
+        <div ref={this.ref} className="tab-title-wrapper">
           <input
             autoFocus
             type="text"
@@ -74,21 +82,31 @@ class TabTitle extends Component {
     }
 
     return (
-      <div className="tab-title-wrapper">
-        <span className="tab-title">{title}</span>
-        <PencilIcon
-          className="btn-title"
-          onClick={() => {
-            this.handleStartEdit(tabKey);
-          }}
-        />
-        <CloseIcon
-          className="btn-title"
-          onClick={() => {
-            this.props.handleRemoveResult(tabKey);
-          }}
-        />
-      </div>
+      <OverlayTrigger
+        placement="top"
+        delay={1000}
+        overlay={
+          <Popover id={`tooltip-${tabKey}`}>
+            {<span className="tab-tooltip">{title}</span>}
+          </Popover>
+        }
+      >
+        <div className="tab-title-wrapper">
+          <span className="tab-title">{title}</span>
+          <PencilIcon
+            className="btn-title"
+            onClick={() => {
+              this.handleStartEdit(tabKey);
+            }}
+          />
+          <CloseIcon
+            className="btn-title"
+            onClick={() => {
+              this.props.handleRemoveResult(tabKey);
+            }}
+          />
+        </div>
+      </OverlayTrigger>
     );
   }
 }

--- a/frontend/src/components/TabbedResults.js
+++ b/frontend/src/components/TabbedResults.js
@@ -74,7 +74,7 @@ class TabTitle extends Component {
     }
 
     return (
-      <div>
+      <div className="tab-title-wrapper">
         <span className="tab-title">{title}</span>
         <PencilIcon
           className="btn-title"

--- a/frontend/src/components/TabbedResults.js
+++ b/frontend/src/components/TabbedResults.js
@@ -86,8 +86,8 @@ class TabTitle extends Component {
         placement="top"
         delay={1000}
         overlay={
-          <Popover id={`tooltip-${tabKey}`}>
-            {<span className="tab-tooltip">{title}</span>}
+          <Popover className="tab-popover" id={`tooltip-${tabKey}`}>
+            {title}
           </Popover>
         }
       >

--- a/frontend/src/components/TabbedResults.less
+++ b/frontend/src/components/TabbedResults.less
@@ -148,7 +148,7 @@
     }
 }
 
-span.tab-tooltip {
+.tab-popover .popover-content {
     max-width: 100%;
     overflow: hidden;
     white-space: nowrap;
@@ -158,5 +158,5 @@ span.tab-tooltip {
     font-family: @monospace-font;
     font-weight: @bold-font-weight;
     color: @dark-text;
-    line-height: @line-height-base;
+    line-height: normal;
 }

--- a/frontend/src/components/TabbedResults.less
+++ b/frontend/src/components/TabbedResults.less
@@ -83,27 +83,49 @@
     }
 
     .nav-tabs {
+        flex: 0 0 auto;
+        display: flex;
+
+        li {
+            flex: 0 1 auto;
+            overflow: hidden;
+        }
+
         li.history-tab-title {
-            float: right;
+            flex: 0 0 auto;
+            margin-left: auto;
 
             .tab-title {
                 width: auto;
             }
         }
 
-        .tab-title {
-            width: 150px;
-            height: @btn-title-size;
-            vertical-align: middle;
-            white-space: nowrap;
+        .tab-title-wrapper {
+            display: flex;
             overflow: hidden;
-            text-overflow: ellipsis;
-            display: inline-block;
-            font-family: @monospace-font;
-            font-weight: @bold-font-weight;
+
+            .tab-title {
+                flex: 0 1 auto;
+                width: 150px;
+                min-width: 30px;
+                height: @btn-title-size;
+                vertical-align: middle;
+                white-space: nowrap;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                display: inline-block;
+                font-family: @monospace-font;
+                font-weight: @bold-font-weight;
+            }
+
+            .btn-title {
+                flex: 0 0 auto;
+            }
         }
 
         > li.active {
+            flex: 0 0 auto;
+
             .btn-title {
                 .icon-btn-variant(@tertiary);
             }

--- a/frontend/src/components/TabbedResults.less
+++ b/frontend/src/components/TabbedResults.less
@@ -86,9 +86,16 @@
         flex: 0 0 auto;
         display: flex;
 
-        li {
+        li:not(.history-tab-title) {
             flex: 0 1 auto;
             overflow: hidden;
+
+            > div {
+                padding-left: 0px;
+                padding-right: 0px;
+                overflow: hidden;
+                min-width: 60px;
+            }
         }
 
         li.history-tab-title {
@@ -103,6 +110,9 @@
         .tab-title-wrapper {
             display: flex;
             overflow: hidden;
+
+            padding-left: 15px;
+            margin-right: 15px;
 
             .tab-title {
                 flex: 0 1 auto;
@@ -136,4 +146,17 @@
             margin-right: 1ex;
         }
     }
+}
+
+span.tab-tooltip {
+    max-width: 100%;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    display: inline-block;
+
+    font-family: @monospace-font;
+    font-weight: @bold-font-weight;
+    color: @dark-text;
+    line-height: @line-height-base;
 }

--- a/frontend/src/variables.less
+++ b/frontend/src/variables.less
@@ -303,7 +303,12 @@
 //== Popovers
 
 //** Popover border color
-@popover-border-color:                @primary;
+@popover-border-color: @primary;
 
 //** Popover arrow width
-@popover-arrow-width:                 0px;
+@popover-arrow-width: 0px;
+
+.popover {
+    border-radius: 0;
+    .box-shadow(3px 3px 0px #c2daea);
+}

--- a/frontend/src/variables.less
+++ b/frontend/src/variables.less
@@ -299,3 +299,11 @@
     border: solid 1px fade(@primary-tint-2, 40%);
     border-radius: 2px;
 }
+
+//== Popovers
+
+//** Popover border color
+@popover-border-color:                @primary;
+
+//** Popover arrow width
+@popover-arrow-width:                 0px;


### PR DESCRIPTION
This is my attempt to fix #145.

![a](https://user-images.githubusercontent.com/1469173/42050633-bf4117b0-7b09-11e8-9302-88d308cf95d4.gif)


One possible improvement to make it easier to use with many tabs is to add tab change with the arrow keys or the mouse wheel. Actually the active tab is supposed to change with the arrow keys by default, but maybe the elements do not get focused or something...

Other improvement could be the addition of @ricardobaeta's drop down with the list of tabs next to history.