### PR TITLE
mention need to satisfy requirements to build from source

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -39,7 +39,7 @@ $ docker-compose pull --include-deps playground
 $ GITBASEPG_REPOS_FOLDER=./repos docker-compose up --force-recreate
 ```
 
-If you want to build and run the playground from sources instead of using the last released version you can do so:
+If you want to build and run the playground from sources instead of using the last released version, make sure your host system satisfies [requirements](CONTRIBUTING.md#requirements). Then you can run:
 
 <details>
 <pre>


### PR DESCRIPTION
Fix: #39

The only place where we document `make compose-serve` is quickstart.
All requirements are already in CONTRIBUTING (including the need to put source code in GOPATH)