### PR TITLE
Fix: make serve

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ build-path:
 
 ## Compiles the assets, and serve the tool through its API
 
-serve: | front-build back-start
+serve: | front-dependencies front-build back-start
 
 compose-serve-latest:
 	$(COMPOSE) pull && \

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -66,7 +66,6 @@ You need to satisfy all [project requirements](#requirements), and then run:
 ```bash
 $ go get -d -u github.com/src-d/gitbase-playground/...
 $ cd $GOPATH/github.com/src-d/gitbase-playground
-$ make dependencies
 $ make serve
 ```
 


### PR DESCRIPTION
`make serve` now installs the frontend deps, otherwise on the latest master it results in:

### Before
```sh
$ git checkout master
$ make serve
mkdir -p build
yarn --cwd ./frontend build
yarn run v1.7.0
$ react-app-rewired build
/bin/sh: react-app-rewired: command not found
error Command failed with exit code 127.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
make: *** [front-build] Error 1
```

### After
```
$ git checkout fix-make-build
$ make serve
mkdir -p build
yarn --cwd ./frontend install
yarn install v1.7.0
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
warning " > eslint-config-airbnb-base@12.1.0" has unmet peer dependency "eslint@^4.9.0".
warning " > eslint-config-airbnb-base@12.1.0" has unmet peer dependency "eslint-plugin-import@^2.7.0".
warning " > eslint-config-prettier@2.9.0" has unmet peer dependency "eslint@>=3.14.1".
warning " > eslint-plugin-jest@21.15.1" has unmet peer dependency "eslint@>=3.6".
warning "react-app-rewire-less > less-loader@4.1.0" has unmet peer dependency "webpack@^2.0.0 || ^3.0.0 || ^4.0.0".
[4/4] 📃  Building fresh packages...
✨  Done in 12.45s.
yarn --cwd ./frontend build
yarn run v1.7.0
$ react-app-rewired build
Creating an optimized production build...
```