### PR TITLE
Add GITBASE_READONLY flag to staging

### DIFF
--- a/.helm-staging.yml
+++ b/.helm-staging.yml
@@ -47,3 +47,4 @@ gitbaseServer:
     tag: v0.14.0-rc2
     pullPolicy: IfNotPresent
   squashEnable: "true"
+  readonly: "true"


### PR DESCRIPTION
Gitbase added a new `GITBASE_READONLY` flag to restrict `CREATE INDEX`: src-d/gitbase#326, tt makes sense to enable it in staging.

This uses the new changes in the chart https://github.com/src-d/charts/pull/59