### PR TITLE
Correct error text for status error without text

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -5,18 +5,22 @@ const selectLimit = envVars.SELECT_LIMIT;
 
 const apiUrl = url => `${serverUrl}${url}`;
 
+function statusError(resp) {
+  return new Error(resp.statusText || `${resp.status} Error`);
+}
+
 function checkStatus(resp) {
   if (resp.status < 200 || resp.status >= 300) {
     return resp
       .json()
       .catch(() => {
-        throw new Error(resp.statusText);
+        throw statusError(resp);
       })
       .then(json => {
         if (json.errors) {
           throw json.errors;
         }
-        throw new Error(resp.statusText);
+        throw statusError(resp);
       });
   }
   return resp;


### PR DESCRIPTION
Fix: #176 

Proxy returns error without text.

<img width="222" alt="screen shot 2018-07-05 at 11 54 29" src="https://user-images.githubusercontent.com/406916/42316983-7d38d974-804b-11e8-8a98-be82eeaf4cc1.png">

Correct headers when everything works as expected:
<img width="309" alt="screen shot 2018-07-05 at 12 04 54" src="https://user-images.githubusercontent.com/406916/42317102-cb64287e-804b-11e8-8104-577d9315eaa2.png">

Headers from proxy:
<img width="450" alt="screen shot 2018-07-05 at 12 05 50" src="https://user-images.githubusercontent.com/406916/42317113-d1d53374-804b-11e8-8f0b-381029f15321.png">

As a workaround when statusText is empty I put text `${resp.code} Error` instead.