### PR TITLE
Fix footer test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ jobs:
       - make docker-build
       - export FOOTER_HTML='<div class="custom-base64-html"></div>'
       - export FOOTER_HTML_BASE64=`echo -n $FOOTER_HTML | base64`
-      - docker run --rm -d --publish 8080:8080 --env GITBASEPG_FOOTER_HTML=$FOOTER_HTML_BASE64 srcd/gitbase-playground:$TRAVIS_BRANCH
+      - docker run --rm -d --publish 8080:8080 --env GITBASEPG_FOOTER_HTML=$FOOTER_HTML_BASE64 srcd/gitbase-playground:$(make version)
       - sleep 5
       - curl http://127.0.0.1:8080 | grep "$FOOTER_HTML"
     # release to github

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,10 @@ clean: front-clean
 build-path:
 	$(MKDIR) $(BUILD_PATH)
 
+.PHONY: version
+version:
+	@echo $(VERSION)
+
 # Compiles the assets, and serves the tool through its API
 
 serve: | front-dependencies front-build back-build back-start

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,9 @@ $(MAKEFILE):
 	@git clone --quiet --depth 1 -b $(CI_BRANCH) $(CI_REPOSITORY) $(CI_PATH);
 -include $(MAKEFILE)
 
+# Override Makefile.main defaults for arguments to be used in `go` commands.
+GO_BUILD_ARGS := -ldflags "$(LD_FLAGS)" -tags "$(GO_BINDATA_TAG)"
+
 # TODO: remove when https://github.com/src-d/ci/pull/84 is merged
 .PHONY: godep
 GODEP ?= $(CI_PATH)/dep
@@ -59,9 +62,6 @@ dependencies: | front-dependencies exit
 # Makefile.main::test -> this::test
 test: front-test
 
-
-# Override Makefile.main defaults for arguments to be used in `go` commands.
-build: GO_BUILD_ARGS := -ldflags "$(LD_FLAGS)" -tags "$(GO_BINDATA_TAG)"
 # this::build -> Makefile.main::build -> Makefile.main::$(COMMANDS)
 # The @echo forces this prerequisites to be run before `Makefile.main::build` ones.
 build: front-build back-build


### PR DESCRIPTION
Fix #202, done on top of #205.

The `GO_BUILD_ARGS` has been moved because it was not being set for `make docker-build`, only for `make build`.