### PR TITLE
Cancel sql requests from the UI

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "format": "eslint --fix 'src/**/*.js'"
   },
   "devDependencies": {
+    "abortcontroller-polyfill": "^1.1.9",
     "eslint-config-airbnb-base": "^12.1.0",
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-jest": "^21.15.1",

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -32,6 +32,10 @@ function normalizeError(err) {
     if (err.title) {
       return err.title;
     }
+    // fetch abort
+    if (err.name === 'AbortError') {
+      return 'The user aborted the request.';
+    }
     // javascript error
     if (err.message) {
       return err.message;
@@ -81,14 +85,15 @@ function apiCall(url, options = {}) {
     .catch(err => Promise.reject(normalizeErrors(err)));
 }
 
-function query(sql) {
+function query(sql, signal) {
   const startTime = new Date();
   return apiCall(`/query`, {
     method: 'POST',
     body: {
       query: sql,
       limit: selectLimit
-    }
+    },
+    signal
   }).then(res => {
     res.meta.elapsedTime = new Date() - startTime;
     return res;

--- a/frontend/src/components/TabbedResults.js
+++ b/frontend/src/components/TabbedResults.js
@@ -198,11 +198,22 @@ class TabbedResults extends Component {
                       </Col>
                     </Row>
                     <Row>
+                      <Col className="text-center message-col" xs={12}>
+                        RUNNING QUERY
+                      </Col>
+                    </Row>
+                    <Row>
                       <Col
                         className="text-center message-col last-message-col"
                         xs={12}
                       >
-                        RUNNING QUERY
+                        <Button
+                          className="animation-action cancel"
+                          bsStyle="gbpl-tertiary"
+                          onClick={() => this.props.handleAbortQuery(key)}
+                        >
+                          CANCEL
+                        </Button>
                       </Col>
                     </Row>
                   </Fragment>
@@ -253,7 +264,7 @@ class TabbedResults extends Component {
                         xs={12}
                       >
                         <Button
-                          className="reload"
+                          className="animation-action reload"
                           bsStyle="gbpl-tertiary"
                           onClick={() => this.props.handleReload(key)}
                         >
@@ -340,6 +351,7 @@ TabbedResults.propTypes = {
   handleResetHistory: PropTypes.func.isRequired,
   handleSetActiveResult: PropTypes.func.isRequired,
   handleReload: PropTypes.func.isRequired,
+  handleAbortQuery: PropTypes.func.isRequired,
   showUAST: PropTypes.func.isRequired,
   languages: CodeViewer.propTypes.languages
 };

--- a/frontend/src/components/TabbedResults.less
+++ b/frontend/src/components/TabbedResults.less
@@ -86,7 +86,7 @@
         }
     }
 
-    button.reload {
+    button.animation-action {
         padding-left: 50px;
         padding-right: 50px;
     }

--- a/frontend/src/setupTests.js
+++ b/frontend/src/setupTests.js
@@ -1,5 +1,6 @@
 import path from 'path';
 import os from 'os';
+import 'abortcontroller-polyfill/dist/polyfill-patch-fetch';
 import initButtonStyles from './utils/bootstrap';
 
 const { LocalStorage } = require('node-localstorage');

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -14,6 +14,10 @@ abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
 
+abortcontroller-polyfill@^1.1.9:
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/abortcontroller-polyfill/-/abortcontroller-polyfill-1.1.9.tgz#9fefe359fda2e9e0932dc85e6106453ac393b2da"
+
 accepts@~1.3.4, accepts@~1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.5.tgz#eb777df6011723a3b14e8a72c0805c8e86746bd2"

--- a/server/handler/render.go
+++ b/server/handler/render.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -19,6 +20,10 @@ type RequestProcessFunc func(*http.Request) (*serializer.Response, error)
 func APIHandlerFunc(rp RequestProcessFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		response, err := rp(r)
+		if err == context.Canceled {
+			return
+		}
+
 		if response == nil {
 			response = serializer.NewEmptyResponse()
 		}

--- a/server/service/common.go
+++ b/server/service/common.go
@@ -1,11 +1,15 @@
 package service
 
-import "database/sql"
+import (
+	"context"
+	"database/sql"
+)
 
 // SQLDB describes a *sql.DB
 type SQLDB interface {
 	Close() error
 	Query(query string, args ...interface{}) (*sql.Rows, error)
+	QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error)
 	QueryRow(query string, args ...interface{}) *sql.Row
 	Ping() error
 }

--- a/server/testing/common.go
+++ b/server/testing/common.go
@@ -1,6 +1,9 @@
 package testing
 
-import "database/sql"
+import (
+	"context"
+	"database/sql"
+)
 
 // MockDB is a mock of *sql.DB
 type MockDB struct{}
@@ -17,6 +20,11 @@ func (db *MockDB) Ping() error {
 
 // Query sends a query to the DB
 func (db *MockDB) Query(query string, args ...interface{}) (*sql.Rows, error) {
+	return nil, nil
+}
+
+// QueryContext executes a query
+func (db *MockDB) QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
Fix #199.

The abort-controller polyfill is used only for the jest tests. All major browsers apparently support AbortCotroller (https://caniuse.com/#search=fetch), and for example for older IE this PR does not break compatibility because it doesn't support fetch API either, which we already use.

I refactored the suspended tab reload to act more like a new query submit. This way the history also shows a new entry for the reload queries. In master reload actions are not reflected in the history.

Tested for chrome and firefox, please let me know if safari works as expected.