### PR TITLE
Change default log level to info

### DIFF
--- a/server/service/logger.go
+++ b/server/service/logger.go
@@ -22,7 +22,7 @@ func NewLogger(env string) *logrus.Logger {
 				logrus.FieldKeyMsg:   "message",
 			},
 		}
-		logger.SetLevel(logrus.WarnLevel)
+		logger.SetLevel(logrus.InfoLevel)
 	}
 
 	return logger


### PR DESCRIPTION
Fix #208.
It makes sense to reserve debug messages for `ENV=dev`, but info should be visible by default.